### PR TITLE
✨ feat: add inverse search (PDF → source) support

### DIFF
--- a/docs/ja/inverse-search.md
+++ b/docs/ja/inverse-search.md
@@ -1,0 +1,122 @@
+# Inverse Search（PDF → ソース）設定ガイド
+
+## 概要
+
+**Inverse Search** とは、PDF ビューワー上でクリックすると、対応する Typst ソースファイルの該当行に Zed エディタがジャンプする機能です。
+
+### なぜビューワー側の設定が必要か
+
+Forward Search（ソース → PDF）は Typster が tinymist LSP へ設定を渡すため自動で動作します。一方、Inverse Search はビューワーがエディタを呼び出す仕組みのため、**各ビューワーのアプリ設定でコマンドを登録する必要があります**。Typster はこの設定を自動化できません。
+
+## 前提条件
+
+`zed` CLI が PATH に通っていること。Zed アプリのメニューから **Zed > Install CLI** を実行してください。確認コマンド:
+
+```sh
+which zed
+# → /usr/local/bin/zed など
+```
+
+---
+
+## ビューワー別セットアップ手順
+
+### Skim（macOS）
+
+1. Skim を開き、**Skim > Preferences** を開く
+2. **Sync** タブを選択
+3. **PDF-TeX Sync Support** セクションの Preset を **Custom** に設定
+4. 以下を入力:
+   - **Command**: `zed`
+   - **Arguments**: `%file:%line`
+5. Preferences を閉じる
+
+PDF 上で `⌘` + クリックすると Zed が該当行を開きます。
+
+---
+
+### SumatraPDF（Windows）
+
+1. SumatraPDF を開き、**Settings > Options** を開く
+2. **Set inverse search command line** フィールドに以下を入力:
+
+   ```
+   zed "%f:%l"
+   ```
+
+3. **OK** をクリック
+
+PDF 上でダブルクリックすると Zed が該当行を開きます。
+
+---
+
+### Zathura（Linux）
+
+`~/.config/zathura/zathurarc` に以下を追加:
+
+```
+set synctex-editor-command "zed \"%{input}:%{line}\""
+```
+
+設定後 Zathura を再起動してください。PDF 上で `Ctrl` + クリックすると Zed が該当行を開きます。
+
+---
+
+### Sioyek（クロスプラットフォーム）
+
+Sioyek のユーザー設定ファイル（`prefs_user.config`）に以下を追加:
+
+```
+inverse_search_command  zed "%1:%2"
+```
+
+ファイルの場所:
+- **Windows**: `%APPDATA%\sioyek\prefs_user.config`
+- **macOS**: `~/Library/Application Support/sioyek/prefs_user.config`
+- **Linux**: `~/.config/sioyek/prefs_user.config`
+
+設定後 Sioyek を再起動してください。
+
+---
+
+### Okular（Linux / KDE）
+
+1. Okular を開き、**Settings > Configure Okular** を開く
+2. **Editor** タブを選択
+3. **Editor** ドロップダウンで **Custom Text Editor** を選択
+4. **Command** フィールドに以下を入力:
+
+   ```
+   zed %f:%l
+   ```
+
+5. **OK** をクリック
+
+PDF 上でクリックすると Zed が該当行を開きます。
+
+---
+
+### Evince（Linux / GNOME）
+
+Evince は D-Bus 経由で Inverse Search を実装しており、エディタコマンドを直接設定する仕組みがありません。Evince での Inverse Search には対応していません。代わりに Zathura や Okular の使用を推奨します。
+
+---
+
+## トラブルシューティング
+
+### クリックしても Zed が起動しない
+
+- `zed` CLI が PATH に通っているか確認: `which zed`
+- ビューワーの設定が保存されているか再確認
+
+### 複数の Zed ウィンドウが開いている場合
+
+`zed path:line` は既存のウィンドウで該当ファイルを開きます。どのウィンドウが前面に来るかはウィンドウマネージャーの挙動に依存します。
+
+### ファイルパスにスペースが含まれる場合
+
+ビューワーによってはコマンドをクォートする必要があります（SumatraPDF の `"%f:%l"` など）。各ビューワーの設定例にはクォートが含まれているため、そのままコピーしてください。
+
+### Skim で行番号がずれる
+
+Typst ファイルを保存してから PDF を再生成することで SyncTeX 情報が更新されます。ビルド後にもう一度試してください。

--- a/src/inverse_search.rs
+++ b/src/inverse_search.rs
@@ -1,0 +1,138 @@
+/// Supported PDF viewer kinds for both forward and inverse search.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ViewerKind {
+    Skim,
+    SumatraPdf,
+    Zathura,
+    Sioyek,
+    Okular,
+    Evince,
+}
+
+/// Setup information for configuring inverse search (PDF → source) in a viewer.
+///
+/// Inverse search is configured on the viewer side: the viewer calls `zed <file>:<line>`
+/// when the user clicks in the PDF. Typster provides this information for documentation
+/// purposes only — it cannot configure external viewers programmatically.
+#[derive(Debug)]
+pub struct InverseSearchSetup {
+    pub viewer: ViewerKind,
+    /// The editor command the viewer should invoke (typically `"zed"`).
+    /// `None` means the viewer does not support a configurable editor command.
+    pub editor_command: Option<&'static str>,
+    /// The argument string with viewer-specific placeholders for file and line.
+    /// `None` means not applicable.
+    pub editor_args: Option<&'static str>,
+    /// Human-readable description of where to configure inverse search in the viewer.
+    pub setup_location: &'static str,
+}
+
+/// Return the inverse search setup information for the given viewer.
+pub fn inverse_search_setup(viewer: ViewerKind) -> InverseSearchSetup {
+    match viewer {
+        ViewerKind::Skim => InverseSearchSetup {
+            viewer,
+            editor_command: Some("zed"),
+            editor_args: Some("%file:%line"),
+            setup_location: "Preferences > Sync > PDF-TeX Sync Support > Preset: Custom",
+        },
+        ViewerKind::SumatraPdf => InverseSearchSetup {
+            viewer,
+            editor_command: Some("zed"),
+            editor_args: Some("\"%f:%l\""),
+            setup_location: "Settings > Options > Set inverse search command line",
+        },
+        ViewerKind::Zathura => InverseSearchSetup {
+            viewer,
+            editor_command: Some("zed"),
+            editor_args: Some("\"%{input}:%{line}\""),
+            setup_location: "zathurarc: set synctex-editor-command",
+        },
+        ViewerKind::Sioyek => InverseSearchSetup {
+            viewer,
+            editor_command: Some("zed"),
+            editor_args: Some("\"%1:%2\""),
+            setup_location: "prefs_user.config: inverse_search_command",
+        },
+        ViewerKind::Okular => InverseSearchSetup {
+            viewer,
+            editor_command: Some("zed"),
+            editor_args: Some("%f:%l"),
+            setup_location:
+                "Settings > Configure Okular > Editor > Custom Text Editor (command field)",
+        },
+        ViewerKind::Evince => InverseSearchSetup {
+            viewer,
+            editor_command: None,
+            editor_args: None,
+            setup_location:
+                "Evince uses D-Bus for inverse search; direct editor configuration is not supported",
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn inverse_search_setup_returns_zed_command_for_skim() {
+        let setup = inverse_search_setup(ViewerKind::Skim);
+        assert_eq!(setup.editor_command, Some("zed"));
+    }
+
+    #[test]
+    fn inverse_search_setup_returns_zed_command_for_sumatra_pdf() {
+        let setup = inverse_search_setup(ViewerKind::SumatraPdf);
+        assert_eq!(setup.editor_command, Some("zed"));
+    }
+
+    #[test]
+    fn inverse_search_setup_returns_zed_command_for_zathura() {
+        let setup = inverse_search_setup(ViewerKind::Zathura);
+        assert_eq!(setup.editor_command, Some("zed"));
+    }
+
+    #[test]
+    fn inverse_search_setup_returns_zed_command_for_sioyek() {
+        let setup = inverse_search_setup(ViewerKind::Sioyek);
+        assert_eq!(setup.editor_command, Some("zed"));
+    }
+
+    #[test]
+    fn inverse_search_setup_returns_zed_command_for_okular() {
+        let setup = inverse_search_setup(ViewerKind::Okular);
+        assert_eq!(setup.editor_command, Some("zed"));
+    }
+
+    #[test]
+    fn inverse_search_setup_returns_no_command_for_evince() {
+        let setup = inverse_search_setup(ViewerKind::Evince);
+        assert_eq!(setup.editor_command, None);
+        assert_eq!(setup.editor_args, None);
+    }
+
+    #[test]
+    fn inverse_search_setup_skim_args_contain_file_and_line_placeholders() {
+        let setup = inverse_search_setup(ViewerKind::Skim);
+        let args = setup.editor_args.unwrap();
+        assert!(args.contains("%file"), "args should contain %file placeholder");
+        assert!(args.contains("%line"), "args should contain %line placeholder");
+    }
+
+    #[test]
+    fn inverse_search_setup_zathura_args_contain_viewer_specific_placeholders() {
+        let setup = inverse_search_setup(ViewerKind::Zathura);
+        let args = setup.editor_args.unwrap();
+        assert!(args.contains("%{input}"), "args should contain %{{input}} placeholder");
+        assert!(args.contains("%{line}"), "args should contain %{{line}} placeholder");
+    }
+
+    #[test]
+    fn inverse_search_setup_sioyek_args_contain_positional_placeholders() {
+        let setup = inverse_search_setup(ViewerKind::Sioyek);
+        let args = setup.editor_args.unwrap();
+        assert!(args.contains("%1"), "args should contain %1 placeholder");
+        assert!(args.contains("%2"), "args should contain %2 placeholder");
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod inverse_search;
 pub mod platform;
 mod tinymist_config;
 mod tinymist_invocation;

--- a/src/tinymist_config/preview_presets.rs
+++ b/src/tinymist_config/preview_presets.rs
@@ -1,10 +1,14 @@
 #![cfg_attr(not(target_arch = "wasm32"), allow(dead_code))]
 
+use crate::inverse_search::ViewerKind;
 use crate::platform::Environment;
 
 /// Detected PDF previewer with its forward search configuration.
 #[derive(Debug)]
 pub struct PreviewerConfig {
+    /// Identifies which viewer was detected; usable for inverse search lookup.
+    #[allow(dead_code)]
+    pub viewer: ViewerKind,
     pub forward_search_executable: String,
     pub forward_search_args: Vec<String>,
 }
@@ -23,6 +27,7 @@ pub fn detect_previewer(env: &dyn Environment) -> Option<PreviewerConfig> {
         }
     }) {
         return Some(PreviewerConfig {
+            viewer: ViewerKind::Skim,
             forward_search_executable: skim,
             forward_search_args: vec![
                 "%l".to_string(),
@@ -35,6 +40,7 @@ pub fn detect_previewer(env: &dyn Environment) -> Option<PreviewerConfig> {
     // Windows: SumatraPDF
     if let Some(sumatra) = env.which("SumatraPDF") {
         return Some(PreviewerConfig {
+            viewer: ViewerKind::SumatraPdf,
             forward_search_executable: sumatra,
             forward_search_args: vec![
                 "-forward-search".to_string(),
@@ -48,6 +54,7 @@ pub fn detect_previewer(env: &dyn Environment) -> Option<PreviewerConfig> {
     // Zathura
     if let Some(zathura) = env.which("zathura") {
         return Some(PreviewerConfig {
+            viewer: ViewerKind::Zathura,
             forward_search_executable: zathura,
             forward_search_args: vec![
                 "--synctex-forward".to_string(),
@@ -60,6 +67,7 @@ pub fn detect_previewer(env: &dyn Environment) -> Option<PreviewerConfig> {
     // Sioyek (cross-platform)
     if let Some(sioyek) = env.which("sioyek") {
         return Some(PreviewerConfig {
+            viewer: ViewerKind::Sioyek,
             forward_search_executable: sioyek,
             forward_search_args: vec![
                 "--reuse-window".to_string(),
@@ -78,6 +86,7 @@ pub fn detect_previewer(env: &dyn Environment) -> Option<PreviewerConfig> {
     // Okular
     if let Some(okular) = env.which("okular") {
         return Some(PreviewerConfig {
+            viewer: ViewerKind::Okular,
             forward_search_executable: okular,
             forward_search_args: vec![
                 "--unique".to_string(),
@@ -89,6 +98,7 @@ pub fn detect_previewer(env: &dyn Environment) -> Option<PreviewerConfig> {
     // Evince
     if let Some(evince) = env.which("evince") {
         return Some(PreviewerConfig {
+            viewer: ViewerKind::Evince,
             forward_search_executable: evince,
             forward_search_args: vec![
                 "--forward-search".to_string(),
@@ -123,6 +133,7 @@ mod tests {
             "/Applications/Skim.app/Contents/SharedSupport/displayline"
         );
         assert_eq!(config.forward_search_args, vec!["%l", "%p", "%i"]);
+        assert_eq!(config.viewer, ViewerKind::Skim);
     }
 
     #[test]
@@ -133,6 +144,7 @@ mod tests {
         assert!(config
             .forward_search_args
             .contains(&"--synctex-forward".to_string()));
+        assert_eq!(config.viewer, ViewerKind::Zathura);
     }
 
     #[test]
@@ -144,6 +156,7 @@ mod tests {
         assert!(config
             .forward_search_executable
             .contains("displayline"));
+        assert_eq!(config.viewer, ViewerKind::Skim);
     }
 
     #[test]
@@ -151,6 +164,7 @@ mod tests {
         let env = FakeEnv::new().with_binary("sioyek");
         let config = detect_previewer(&env).unwrap();
         assert_eq!(config.forward_search_args[0], "--reuse-window");
+        assert_eq!(config.viewer, ViewerKind::Sioyek);
     }
 
     #[test]
@@ -158,6 +172,7 @@ mod tests {
         let env = FakeEnv::new().with_binary("okular");
         let config = detect_previewer(&env).unwrap();
         assert!(config.forward_search_args[1].contains("src:"));
+        assert_eq!(config.viewer, ViewerKind::Okular);
     }
 
     #[test]
@@ -165,5 +180,6 @@ mod tests {
         let env = FakeEnv::new().with_binary("evince");
         let config = detect_previewer(&env).unwrap();
         assert_eq!(config.forward_search_args[0], "--forward-search");
+        assert_eq!(config.viewer, ViewerKind::Evince);
     }
 }


### PR DESCRIPTION
## Summary

- `src/inverse_search.rs` を新規追加。`ViewerKind` enum と `InverseSearchSetup` 構造体により、6つの PDF ビューワー（Skim / SumatraPDF / Zathura / Sioyek / Okular / Evince）の inverse search セットアップ情報を提供
- `PreviewerConfig` に `viewer: ViewerKind` フィールドを追加し、検出ビューワーの種別を識別可能に
- `docs/ja/inverse-search.md` を新規追加。各ビューワーの設定手順とトラブルシューティングを日本語で記載

## 背景

Closes #1

Forward Search（ソース → PDF）は実装済みだが、Inverse Search（PDF → ソース）は未実装だった。tinymist LSP に `inverseSearch` 設定フィールドは存在しないため、ビューワー側でエディタ呼び出しコマンドを設定する方式を採用。Typster は設定情報の提供に専念し、外部ビューワーへの自動設定は行わない。

## Test plan

- [x] `cargo test` — 31テスト全通過（新規9テスト含む）
- [x] `cargo build --target wasm32-wasip1` — 警告なしでビルド成功
- [ ] Skim で `docs/ja/inverse-search.md` の手順に従い inverse search の動作を手動確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)