### PR TITLE
✨ feat: add tinymist browser preview support [BEHAVIORAL]

### DIFF
--- a/docs/ja/inverse-search.md
+++ b/docs/ja/inverse-search.md
@@ -4,9 +4,59 @@
 
 **Inverse Search** とは、PDF ビューワー上でクリックすると、対応する Typst ソースファイルの該当行に Zed エディタがジャンプする機能です。
 
-### なぜビューワー側の設定が必要か
+Typster は 2 種類のプレビュー方式に対応しています:
 
-Forward Search（ソース → PDF）は Typster が tinymist LSP へ設定を渡すため自動で動作します。一方、Inverse Search はビューワーがエディタを呼び出す仕組みのため、**各ビューワーのアプリ設定でコマンドを登録する必要があります**。Typster はこの設定を自動化できません。
+- **ブラウザプレビュー**（推奨・設定不要）: 外部ビューワーが検出されない場合、tinymist のバックグラウンドプレビューサーバーが自動的に有効化されます。ブラウザ（Chrome など）で `http://127.0.0.1:23635` を開くと SVG ベースのプレビューが表示され、Forward/Inverse Search は WebSocket 経由で自動的に動作します。
+- **外部ビューワー**（手動設定が必要）: Skim, SumatraPDF, Zathura など PDF ビューワーをインストールすると自動検出されます。Forward Search は自動設定されますが、Inverse Search はビューワー側でエディタコマンドを登録する必要があります。
+
+> **ブラウザプレビューの要件**: tinymist バージョン 0.13.6 以降が必要です。PATH 上にそれより古い tinymist がある場合はアップデートするか、設定で `lsp.tinymist.binary.path` に最新バイナリのパスを指定してください。
+
+### プレビューワーの指定方法
+
+Zed の `settings.json` で `typsterPreviewer` キーを指定することで、使用するプレビューワーを明示的に選択できます:
+
+```json
+{
+  "lsp": {
+    "tinymist": {
+      "settings": {
+        "typsterPreviewer": "browser"
+      }
+    }
+  }
+}
+```
+
+指定可能な値:
+
+| 値 | 説明 |
+|----|------|
+| `"auto"` | 自動検出（デフォルト）。外部ビューワーが見つからない場合はビルトインにフォールバック |
+| `"browser"` | tinymist のブラウザプレビュー（Chrome など任意のブラウザで利用可）|
+| `"skim"` | Skim（macOS）|
+| `"sumatrapdf"` | SumatraPDF（Windows）|
+| `"zathura"` | Zathura（Linux）|
+| `"sioyek"` | Sioyek（クロスプラットフォーム）|
+| `"okular"` | Okular（Linux / KDE）|
+| `"evince"` | Evince（Linux / GNOME）|
+
+> **注意**: 外部ビューワーを指定したがインストールされていない場合、自動的にブラウザプレビューにフォールバックします。
+
+### ブラウザプレビューの使い方
+
+1. `typsterPreviewer: "browser"` を設定するか、外部 PDF ビューワーをインストールしていない状態で Typst ファイルを開く
+2. ブラウザ（Chrome など）で `http://127.0.0.1:23635` にアクセス
+3. PDF をエクスポートせずリアルタイムプレビューが確認できます
+4. ブラウザ上でクリックすると Zed の対応行にジャンプします（Inverse Search）
+5. Zed でカーソルを動かすとブラウザのスクロール位置も追従します（Forward Search）
+
+> **注意**: ユーザー設定で `preview` キーを部分的に上書きすると、自動設定の `preview` オブジェクト全体が置き換わります。これは既存の `forwardSearch` と同じ動作です。`background.enabled` を維持したまま他のキーを変更する場合は、`preview` オブジェクト全体を設定してください。
+
+---
+
+### なぜ外部ビューワーには手動設定が必要か
+
+Inverse Search はビューワーがエディタを呼び出す仕組みのため、**各ビューワーのアプリ設定でコマンドを登録する必要があります**。Typster はこの設定を自動化できません。
 
 ## 前提条件
 

--- a/src/inverse_search.rs
+++ b/src/inverse_search.rs
@@ -7,6 +7,8 @@ pub enum ViewerKind {
     Sioyek,
     Okular,
     Evince,
+    /// tinymist's built-in browser preview server (no external viewer needed).
+    BuiltinPreview,
 }
 
 /// Setup information for configuring inverse search (PDF → source) in a viewer.
@@ -67,6 +69,13 @@ pub fn inverse_search_setup(viewer: ViewerKind) -> InverseSearchSetup {
             editor_args: None,
             setup_location:
                 "Evince uses D-Bus for inverse search; direct editor configuration is not supported",
+        },
+        ViewerKind::BuiltinPreview => InverseSearchSetup {
+            viewer,
+            editor_command: None,
+            editor_args: None,
+            setup_location:
+                "Built-in preview handles inverse search via WebSocket; no manual setup required",
         },
     }
 }
@@ -134,5 +143,21 @@ mod tests {
         let args = setup.editor_args.unwrap();
         assert!(args.contains("%1"), "args should contain %1 placeholder");
         assert!(args.contains("%2"), "args should contain %2 placeholder");
+    }
+
+    #[test]
+    fn inverse_search_setup_returns_no_command_for_builtin_preview() {
+        let setup = inverse_search_setup(ViewerKind::BuiltinPreview);
+        assert_eq!(setup.editor_command, None);
+        assert_eq!(setup.editor_args, None);
+    }
+
+    #[test]
+    fn inverse_search_setup_builtin_preview_indicates_no_manual_setup() {
+        let setup = inverse_search_setup(ViewerKind::BuiltinPreview);
+        assert!(
+            setup.setup_location.contains("WebSocket"),
+            "setup_location should mention WebSocket"
+        );
     }
 }

--- a/src/tinymist_config/mod.rs
+++ b/src/tinymist_config/mod.rs
@@ -4,8 +4,54 @@ pub mod preview_presets;
 
 use serde_json::{Map, Value};
 
+use crate::inverse_search::ViewerKind;
 use crate::platform::Environment;
-use preview_presets::detect_previewer;
+use preview_presets::{builtin_preview_defaults, config_for_viewer, detect_previewer};
+
+/// User-specified previewer choice, read from `lsp.tinymist.settings.typsterPreviewer`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PreviewerChoice {
+    /// Auto-detect an external viewer; fall back to browser preview if none found (default).
+    Auto,
+    /// Force tinymist's browser preview server regardless of installed viewers.
+    Browser,
+    Skim,
+    SumatraPdf,
+    Zathura,
+    Sioyek,
+    Okular,
+    Evince,
+}
+
+impl PreviewerChoice {
+    /// Parse from the string value of `typsterPreviewer`.
+    /// Unknown values fall back to `Auto`.
+    pub fn from_str(s: &str) -> Self {
+        match s {
+            "browser" => PreviewerChoice::Browser,
+            "skim" => PreviewerChoice::Skim,
+            "sumatrapdf" => PreviewerChoice::SumatraPdf,
+            "zathura" => PreviewerChoice::Zathura,
+            "sioyek" => PreviewerChoice::Sioyek,
+            "okular" => PreviewerChoice::Okular,
+            "evince" => PreviewerChoice::Evince,
+            _ => PreviewerChoice::Auto,
+        }
+    }
+}
+
+/// Extract and remove the `typsterPreviewer` key from user settings.
+/// If the key is present and its value is a string, parse it as a `PreviewerChoice`.
+/// The key is removed from `user_settings` so it is not forwarded to tinymist.
+pub fn extract_previewer_choice(user_settings: &mut Option<Value>) -> PreviewerChoice {
+    let Some(Value::Object(map)) = user_settings else {
+        return PreviewerChoice::Auto;
+    };
+    match map.remove("typsterPreviewer") {
+        Some(Value::String(s)) => PreviewerChoice::from_str(&s),
+        _ => PreviewerChoice::Auto,
+    }
+}
 
 /// Detect which Typst formatter is available on the system.
 /// Returns "typstyle" or "typstfmt" if found, None otherwise.
@@ -19,20 +65,78 @@ fn detect_formatter(env: &dyn Environment) -> Option<&'static str> {
     }
 }
 
+/// Apply previewer configuration to `map` based on `choice`.
+/// External-viewer choices set `forwardSearch` + `exportPdf: "onSave"`.
+/// Built-in preview sets `preview.background.enabled` + `exportPdf: "never"`.
+/// For specific external viewers, falls back to built-in if the viewer is not installed.
+fn apply_previewer_config(
+    map: &mut Map<String, Value>,
+    choice: PreviewerChoice,
+    env: &dyn Environment,
+) {
+    let viewer_kind = match choice {
+        PreviewerChoice::Browser => {
+            use_browser_preview(map);
+            return;
+        }
+        PreviewerChoice::Auto => {
+            // Auto-detect: try each viewer in priority order.
+            if let Some(previewer) = detect_previewer(env) {
+                use_external_viewer(map, previewer);
+            } else {
+                use_browser_preview(map);
+            }
+            return;
+        }
+        PreviewerChoice::Skim => ViewerKind::Skim,
+        PreviewerChoice::SumatraPdf => ViewerKind::SumatraPdf,
+        PreviewerChoice::Zathura => ViewerKind::Zathura,
+        PreviewerChoice::Sioyek => ViewerKind::Sioyek,
+        PreviewerChoice::Okular => ViewerKind::Okular,
+        PreviewerChoice::Evince => ViewerKind::Evince,
+    };
+
+    // Specific viewer: use it if installed, otherwise fall back to built-in.
+    if let Some(previewer) = config_for_viewer(viewer_kind, env) {
+        use_external_viewer(map, previewer);
+    } else {
+        use_browser_preview(map);
+    }
+}
+
+fn use_external_viewer(map: &mut Map<String, Value>, previewer: preview_presets::PreviewerConfig) {
+    map.insert(
+        "forwardSearch".to_string(),
+        serde_json::json!({
+            "command": previewer.forward_search_executable,
+            "args": previewer.forward_search_args,
+        }),
+    );
+    // External viewer needs the exported PDF file to display.
+    map.insert(
+        "exportPdf".to_string(),
+        Value::String("onSave".to_string()),
+    );
+}
+
+fn use_browser_preview(map: &mut Map<String, Value>) {
+    // Built-in preview renders directly from source; PDF export is not needed.
+    map.insert(
+        "preview".to_string(),
+        Value::Object(builtin_preview_defaults()),
+    );
+    map.insert("exportPdf".to_string(), Value::String("never".to_string()));
+}
+
 /// Build the auto-detected portion of tinymist workspace configuration.
-/// This includes forward search, formatter mode, and sensible defaults.
-pub fn build_auto_detected_config(env: &dyn Environment) -> Map<String, Value> {
+/// `choice` controls which previewer is selected (defaults to `Auto`).
+pub fn build_auto_detected_config(
+    env: &dyn Environment,
+    choice: PreviewerChoice,
+) -> Map<String, Value> {
     let mut map = Map::new();
 
-    if let Some(previewer) = detect_previewer(env) {
-        map.insert(
-            "forwardSearch".to_string(),
-            serde_json::json!({
-                "command": previewer.forward_search_executable,
-                "args": previewer.forward_search_args,
-            }),
-        );
-    }
+    apply_previewer_config(&mut map, choice, env);
 
     if let Some(formatter) = detect_formatter(env) {
         map.insert(
@@ -40,9 +144,6 @@ pub fn build_auto_detected_config(env: &dyn Environment) -> Map<String, Value> {
             Value::String(formatter.to_string()),
         );
     }
-
-    map.entry("exportPdf".to_string())
-        .or_insert_with(|| Value::String("onSave".to_string()));
 
     map.entry("semanticTokens".to_string())
         .or_insert_with(|| Value::String("enable".to_string()));
@@ -75,12 +176,14 @@ pub fn build_workspace_config(
     use crate::platform::WorktreeEnv;
     use zed_extension_api::settings::LspSettings;
 
-    let user_settings = LspSettings::for_worktree(server_id_str, worktree)
+    let mut user_settings = LspSettings::for_worktree(server_id_str, worktree)
         .ok()
         .and_then(|s| s.settings.clone());
 
+    let choice = extract_previewer_choice(&mut user_settings);
+
     let env = WorktreeEnv(worktree);
-    let auto_config = build_auto_detected_config(&env);
+    let auto_config = build_auto_detected_config(&env, choice);
 
     if auto_config.is_empty() {
         return user_settings;
@@ -121,14 +224,14 @@ mod tests {
     #[test]
     fn build_auto_detected_config_sets_typstyle_when_available() {
         let env = FakeEnv::new().with_binary("typstyle");
-        let config = build_auto_detected_config(&env);
+        let config = build_auto_detected_config(&env, PreviewerChoice::Auto);
         assert_eq!(config["formatterMode"], "typstyle");
     }
 
     #[test]
     fn build_auto_detected_config_sets_typstfmt_when_typstyle_not_available() {
         let env = FakeEnv::new().with_binary("typstfmt");
-        let config = build_auto_detected_config(&env);
+        let config = build_auto_detected_config(&env, PreviewerChoice::Auto);
         assert_eq!(config["formatterMode"], "typstfmt");
     }
 
@@ -137,21 +240,22 @@ mod tests {
         let env = FakeEnv::new()
             .with_binary("typstyle")
             .with_binary("typstfmt");
-        let config = build_auto_detected_config(&env);
+        let config = build_auto_detected_config(&env, PreviewerChoice::Auto);
         assert_eq!(config["formatterMode"], "typstyle");
     }
 
     #[test]
     fn build_auto_detected_config_includes_export_pdf_default() {
+        // Without an external viewer, built-in preview is used and PDF export is disabled.
         let env = FakeEnv::new();
-        let config = build_auto_detected_config(&env);
-        assert_eq!(config["exportPdf"], "onSave");
+        let config = build_auto_detected_config(&env, PreviewerChoice::Auto);
+        assert_eq!(config["exportPdf"], "never");
     }
 
     #[test]
     fn build_auto_detected_config_includes_semantic_tokens_default() {
         let env = FakeEnv::new();
-        let config = build_auto_detected_config(&env);
+        let config = build_auto_detected_config(&env, PreviewerChoice::Auto);
         assert_eq!(config["semanticTokens"], "enable");
     }
 
@@ -165,5 +269,124 @@ mod tests {
     fn detect_formatter_returns_typstyle_when_available() {
         let env = FakeEnv::new().with_binary("typstyle");
         assert_eq!(detect_formatter(&env), Some("typstyle"));
+    }
+
+    #[test]
+    fn build_auto_detected_config_enables_browser_preview_when_no_viewer_found() {
+        let env = FakeEnv::new();
+        let config = build_auto_detected_config(&env, PreviewerChoice::Auto);
+        assert_eq!(config["preview"]["background"]["enabled"], true);
+    }
+
+    #[test]
+    fn build_auto_detected_config_sets_export_pdf_never_when_browser_preview() {
+        let env = FakeEnv::new();
+        let config = build_auto_detected_config(&env, PreviewerChoice::Auto);
+        assert_eq!(config["exportPdf"], "never");
+    }
+
+    #[test]
+    fn build_auto_detected_config_does_not_set_forward_search_when_no_viewer_found() {
+        let env = FakeEnv::new();
+        let config = build_auto_detected_config(&env, PreviewerChoice::Auto);
+        assert!(!config.contains_key("forwardSearch"));
+    }
+
+    #[test]
+    fn build_auto_detected_config_sets_export_pdf_on_save_when_external_viewer_found() {
+        let env = FakeEnv::new().with_binary("zathura");
+        let config = build_auto_detected_config(&env, PreviewerChoice::Auto);
+        assert_eq!(config["exportPdf"], "onSave");
+    }
+
+    #[test]
+    fn build_auto_detected_config_does_not_set_preview_when_external_viewer_found() {
+        let env = FakeEnv::new().with_binary("zathura");
+        let config = build_auto_detected_config(&env, PreviewerChoice::Auto);
+        assert!(!config.contains_key("preview"));
+    }
+
+    // --- PreviewerChoice::Browser ---
+
+    #[test]
+    fn build_auto_detected_config_forces_browser_when_choice_is_browser() {
+        // Even if an external viewer is installed, Browser choice ignores it.
+        let env = FakeEnv::new().with_binary("zathura");
+        let config = build_auto_detected_config(&env, PreviewerChoice::Browser);
+        assert_eq!(config["preview"]["background"]["enabled"], true);
+        assert_eq!(config["exportPdf"], "never");
+        assert!(!config.contains_key("forwardSearch"));
+    }
+
+    // --- Specific viewer choices ---
+
+    #[test]
+    fn build_auto_detected_config_uses_zathura_when_choice_is_zathura_and_installed() {
+        let env = FakeEnv::new().with_binary("zathura");
+        let config = build_auto_detected_config(&env, PreviewerChoice::Zathura);
+        assert_eq!(config["exportPdf"], "onSave");
+        assert!(config["forwardSearch"]["command"]
+            .as_str()
+            .unwrap()
+            .contains("zathura"));
+    }
+
+    #[test]
+    fn build_auto_detected_config_falls_back_to_browser_when_specified_viewer_not_installed() {
+        // User specifies Skim but it is not installed; falls back to built-in.
+        let env = FakeEnv::new();
+        let config = build_auto_detected_config(&env, PreviewerChoice::Skim);
+        assert_eq!(config["preview"]["background"]["enabled"], true);
+        assert_eq!(config["exportPdf"], "never");
+        assert!(!config.contains_key("forwardSearch"));
+    }
+
+    // --- extract_previewer_choice ---
+
+    #[test]
+    fn extract_previewer_choice_returns_auto_when_key_absent() {
+        let mut settings = Some(json!({"otherKey": true}));
+        let choice = extract_previewer_choice(&mut settings);
+        assert_eq!(choice, PreviewerChoice::Auto);
+        // Other keys are preserved.
+        assert_eq!(settings.unwrap()["otherKey"], true);
+    }
+
+    #[test]
+    fn extract_previewer_choice_parses_browser_string() {
+        let mut settings = Some(json!({"typsterPreviewer": "browser"}));
+        let choice = extract_previewer_choice(&mut settings);
+        assert_eq!(choice, PreviewerChoice::Browser);
+    }
+
+    #[test]
+    fn extract_previewer_choice_parses_skim_string() {
+        let mut settings = Some(json!({"typsterPreviewer": "skim"}));
+        let choice = extract_previewer_choice(&mut settings);
+        assert_eq!(choice, PreviewerChoice::Skim);
+    }
+
+    #[test]
+    fn extract_previewer_choice_removes_key_from_settings() {
+        let mut settings = Some(json!({"typsterPreviewer": "zathura", "exportPdf": "onSave"}));
+        extract_previewer_choice(&mut settings);
+        // typsterPreviewer must not be forwarded to tinymist.
+        let map = settings.unwrap();
+        assert!(!map.as_object().unwrap().contains_key("typsterPreviewer"));
+        assert_eq!(map["exportPdf"], "onSave");
+    }
+
+    #[test]
+    fn extract_previewer_choice_returns_auto_for_unknown_value() {
+        let mut settings = Some(json!({"typsterPreviewer": "chrome"}));
+        let choice = extract_previewer_choice(&mut settings);
+        assert_eq!(choice, PreviewerChoice::Auto);
+    }
+
+    #[test]
+    fn extract_previewer_choice_returns_auto_when_settings_is_none() {
+        let mut settings = None;
+        let choice = extract_previewer_choice(&mut settings);
+        assert_eq!(choice, PreviewerChoice::Auto);
     }
 }

--- a/src/tinymist_config/preview_presets.rs
+++ b/src/tinymist_config/preview_presets.rs
@@ -2,6 +2,7 @@
 
 use crate::inverse_search::ViewerKind;
 use crate::platform::Environment;
+use serde_json::{Map, Value};
 
 /// Detected PDF previewer with its forward search configuration.
 #[derive(Debug)]
@@ -13,62 +14,53 @@ pub struct PreviewerConfig {
     pub forward_search_args: Vec<String>,
 }
 
-/// Detect an available PDF previewer and return its forward search config.
-/// Priority order matches zed-latex: Skim (macOS), SumatraPDF (Windows),
-/// then Zathura, Sioyek, Okular, Evince (Linux/cross-platform).
-pub fn detect_previewer(env: &dyn Environment) -> Option<PreviewerConfig> {
-    // macOS: Skim
-    let skim_path = "/Applications/Skim.app/Contents/SharedSupport/displayline";
-    if let Some(skim) = env.which("skimapp").or_else(|| {
-        if env.path_exists(skim_path) {
-            Some(skim_path.to_string())
-        } else {
-            None
+/// Return the forward search configuration for a specific viewer kind,
+/// if that viewer's binary or application path is available on the system.
+/// Returns `None` if the viewer is not installed or if the kind is `BuiltinPreview`.
+pub fn config_for_viewer(viewer: ViewerKind, env: &dyn Environment) -> Option<PreviewerConfig> {
+    match viewer {
+        ViewerKind::Skim => {
+            let skim_path = "/Applications/Skim.app/Contents/SharedSupport/displayline";
+            env.which("skimapp")
+                .or_else(|| {
+                    if env.path_exists(skim_path) {
+                        Some(skim_path.to_string())
+                    } else {
+                        None
+                    }
+                })
+                .map(|exe| PreviewerConfig {
+                    viewer: ViewerKind::Skim,
+                    forward_search_executable: exe,
+                    forward_search_args: vec![
+                        "%l".to_string(),
+                        "%p".to_string(),
+                        "%i".to_string(),
+                    ],
+                })
         }
-    }) {
-        return Some(PreviewerConfig {
-            viewer: ViewerKind::Skim,
-            forward_search_executable: skim,
-            forward_search_args: vec![
-                "%l".to_string(),
-                "%p".to_string(),
-                "%i".to_string(),
-            ],
-        });
-    }
-
-    // Windows: SumatraPDF
-    if let Some(sumatra) = env.which("SumatraPDF") {
-        return Some(PreviewerConfig {
+        ViewerKind::SumatraPdf => env.which("SumatraPDF").map(|exe| PreviewerConfig {
             viewer: ViewerKind::SumatraPdf,
-            forward_search_executable: sumatra,
+            forward_search_executable: exe,
             forward_search_args: vec![
                 "-forward-search".to_string(),
                 "%i".to_string(),
                 "%l".to_string(),
                 "%p".to_string(),
             ],
-        });
-    }
-
-    // Zathura
-    if let Some(zathura) = env.which("zathura") {
-        return Some(PreviewerConfig {
+        }),
+        ViewerKind::Zathura => env.which("zathura").map(|exe| PreviewerConfig {
             viewer: ViewerKind::Zathura,
-            forward_search_executable: zathura,
+            forward_search_executable: exe,
             forward_search_args: vec![
                 "--synctex-forward".to_string(),
                 "%l:1:%i".to_string(),
                 "%p".to_string(),
             ],
-        });
-    }
-
-    // Sioyek (cross-platform)
-    if let Some(sioyek) = env.which("sioyek") {
-        return Some(PreviewerConfig {
+        }),
+        ViewerKind::Sioyek => env.which("sioyek").map(|exe| PreviewerConfig {
             viewer: ViewerKind::Sioyek,
-            forward_search_executable: sioyek,
+            forward_search_executable: exe,
             forward_search_args: vec![
                 "--reuse-window".to_string(),
                 "--execute-command".to_string(),
@@ -80,36 +72,60 @@ pub fn detect_previewer(env: &dyn Environment) -> Option<PreviewerConfig> {
                 "--open".to_string(),
                 "%p".to_string(),
             ],
-        });
-    }
-
-    // Okular
-    if let Some(okular) = env.which("okular") {
-        return Some(PreviewerConfig {
+        }),
+        ViewerKind::Okular => env.which("okular").map(|exe| PreviewerConfig {
             viewer: ViewerKind::Okular,
-            forward_search_executable: okular,
+            forward_search_executable: exe,
             forward_search_args: vec![
                 "--unique".to_string(),
                 "file:%p#src:%l%i".to_string(),
             ],
-        });
-    }
-
-    // Evince
-    if let Some(evince) = env.which("evince") {
-        return Some(PreviewerConfig {
+        }),
+        ViewerKind::Evince => env.which("evince").map(|exe| PreviewerConfig {
             viewer: ViewerKind::Evince,
-            forward_search_executable: evince,
+            forward_search_executable: exe,
             forward_search_args: vec![
                 "--forward-search".to_string(),
                 "%i".to_string(),
                 "%l".to_string(),
                 "%p".to_string(),
             ],
-        });
+        }),
+        ViewerKind::BuiltinPreview => None,
     }
+}
 
-    None
+/// Detect an available PDF previewer and return its forward search config.
+/// Priority order matches zed-latex: Skim (macOS), SumatraPDF (Windows),
+/// then Zathura, Sioyek, Okular, Evince (Linux/cross-platform).
+pub fn detect_previewer(env: &dyn Environment) -> Option<PreviewerConfig> {
+    const PRIORITY: &[ViewerKind] = &[
+        ViewerKind::Skim,
+        ViewerKind::SumatraPdf,
+        ViewerKind::Zathura,
+        ViewerKind::Sioyek,
+        ViewerKind::Okular,
+        ViewerKind::Evince,
+    ];
+    PRIORITY
+        .iter()
+        .find_map(|&kind| config_for_viewer(kind, env))
+}
+
+/// Return the minimum configuration to enable tinymist's built-in preview server.
+/// Used as fallback when no external PDF viewer is detected.
+///
+/// Only `background.enabled` is set here; all other `preview.*` keys use tinymist's
+/// own defaults (requires tinymist ≥ 0.13.6).
+/// The returned map is intended to be inserted as the value of the `"preview"` key
+/// in the workspace configuration sent to tinymist.
+pub fn builtin_preview_defaults() -> Map<String, Value> {
+    let mut preview = Map::new();
+    preview.insert(
+        "background".to_string(),
+        serde_json::json!({ "enabled": true }),
+    );
+    preview
 }
 
 #[cfg(test)]
@@ -153,9 +169,7 @@ mod tests {
             .with_path("/Applications/Skim.app/Contents/SharedSupport/displayline")
             .with_binary("zathura");
         let config = detect_previewer(&env).unwrap();
-        assert!(config
-            .forward_search_executable
-            .contains("displayline"));
+        assert!(config.forward_search_executable.contains("displayline"));
         assert_eq!(config.viewer, ViewerKind::Skim);
     }
 
@@ -181,5 +195,31 @@ mod tests {
         let config = detect_previewer(&env).unwrap();
         assert_eq!(config.forward_search_args[0], "--forward-search");
         assert_eq!(config.viewer, ViewerKind::Evince);
+    }
+
+    #[test]
+    fn config_for_viewer_returns_skim_config_when_path_exists() {
+        let env = FakeEnv::new()
+            .with_path("/Applications/Skim.app/Contents/SharedSupport/displayline");
+        let config = config_for_viewer(ViewerKind::Skim, &env).unwrap();
+        assert_eq!(config.viewer, ViewerKind::Skim);
+    }
+
+    #[test]
+    fn config_for_viewer_returns_none_when_skim_not_installed() {
+        let env = FakeEnv::new();
+        assert!(config_for_viewer(ViewerKind::Skim, &env).is_none());
+    }
+
+    #[test]
+    fn config_for_viewer_returns_none_for_builtin_preview() {
+        let env = FakeEnv::new();
+        assert!(config_for_viewer(ViewerKind::BuiltinPreview, &env).is_none());
+    }
+
+    #[test]
+    fn builtin_preview_defaults_enables_background_server() {
+        let defaults = builtin_preview_defaults();
+        assert_eq!(defaults["background"]["enabled"], true);
     }
 }


### PR DESCRIPTION
## Summary

Closes #2

Issue #2 で要望されたエディタ内PDFビューワーは Zed Extension API の制約（WebView/カスタムタブAPIが存在しない）により実装不可能なため、tinymist のビルトインブラウザプレビューサーバーを代替として統合しました。

- 外部PDFビューワー未検出時、tinymist のバックグラウンドプレビューサーバーを自動有効化（`http://127.0.0.1:23635`）
- ユーザーが `typsterPreviewer` 設定でプレビューワーを明示指定可能（`"browser"`, `"skim"`, `"zathura"` 等）
- Forward/Inverse Search は WebSocket 経由で自動動作（外部ビューワー設定不要）
- `exportPdf` のデフォルト値を外部ビューワーなし環境で `"onSave"` → `"never"` に変更

## 主な変更

### 新設定: `typsterPreviewer`

```json
{
  "lsp": {
    "tinymist": {
      "settings": {
        "typsterPreviewer": "browser"
      }
    }
  }
}
```

| 値 | 動作 |
|----|------|
| `"auto"` (デフォルト) | 外部ビューワー自動検出、なければブラウザプレビューにフォールバック |
| `"browser"` | tinymist ブラウザプレビューを強制使用 |
| `"skim"` / `"zathura"` / etc. | 指定ビューワー使用、未インストールならブラウザプレビューへフォールバック |

### アーキテクチャ変更

- `PreviewerChoice` enum 追加（`src/tinymist_config/mod.rs`）
- `extract_previewer_choice()` 追加 — `typsterPreviewer` キーを設定から抽出・除去し tinymist に転送しない
- `config_for_viewer(kind, env)` 追加 — `detect_previewer` をリファクタリングし特定ビューワー指定に対応
- `builtin_preview_defaults()` 追加 — ブラウザプレビューの最小設定（`preview.background.enabled: true`）

## Test plan

- [x] `cargo test` — 51テスト全てパス
- [x] `cargo build --target wasm32-wasip1` — WASMビルド成功
- [ ] 外部ビューワーなし環境で `http://127.0.0.1:23635` にブラウザでアクセスしプレビュー確認
- [ ] `typsterPreviewer: "skim"` で Skim が起動することを確認
- [ ] `typsterPreviewer: "browser"` で Skim がインストールされていても無視されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)