### PR TITLE
feat: implement /typst-docs and /typst-symbols slash commands

### DIFF
--- a/extension.toml
+++ b/extension.toml
@@ -13,3 +13,13 @@ language = "Typst"
 [grammars.typst]
 repository = "https://github.com/uben0/tree-sitter-typst"
 commit = "46cf4ded12ee974a70bf8457263b67ad7ee0379d"
+
+[slash_commands.typst-docs]
+description = "Show Typst standard library function documentation (signature, parameters, examples)"
+requires_argument = true
+tooltip_text = "Insert Typst function documentation as context"
+
+[slash_commands.typst-symbols]
+description = "Show Typst math symbols by category (arrow, greek, operator, relation, set, logic, accent, misc)"
+requires_argument = true
+tooltip_text = "Insert Typst symbol list as context"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 mod code_label;
 pub mod inverse_search;
 pub mod platform;
+mod slash_commands;
 mod tinymist_config;
 mod tinymist_invocation;
 
@@ -76,6 +77,53 @@ impl zed::Extension for TypsterExtension {
         symbol: zed::lsp::Symbol,
     ) -> Option<zed::CodeLabel> {
         code_label::label_for_symbol(&symbol)
+    }
+
+    fn complete_slash_command_argument(
+        &self,
+        command: zed::SlashCommand,
+        args: Vec<String>,
+    ) -> Result<Vec<zed::SlashCommandArgumentCompletion>> {
+        let completions = match command.name.as_str() {
+            "typst-docs" => slash_commands::complete_typst_docs(&args),
+            "typst-symbols" => slash_commands::complete_typst_symbols(&args),
+            _ => return Ok(vec![]),
+        };
+        Ok(completions
+            .into_iter()
+            .map(|c| zed::SlashCommandArgumentCompletion {
+                label: c.label,
+                new_text: c.new_text,
+                run_command: c.run_command,
+            })
+            .collect())
+    }
+
+    fn run_slash_command(
+        &self,
+        command: zed::SlashCommand,
+        args: Vec<String>,
+        _worktree: Option<&zed::Worktree>,
+    ) -> Result<zed::SlashCommandOutput> {
+        let output = match command.name.as_str() {
+            "typst-docs" => slash_commands::run_typst_docs(&args),
+            "typst-symbols" => slash_commands::run_typst_symbols(&args),
+            _ => Err(format!("Unknown command: {}", command.name)),
+        }?;
+        Ok(zed::SlashCommandOutput {
+            text: output.text,
+            sections: output
+                .sections
+                .into_iter()
+                .map(|s| zed::SlashCommandOutputSection {
+                    range: zed::Range {
+                        start: s.range.start as u32,
+                        end: s.range.end as u32,
+                    },
+                    label: s.label,
+                })
+                .collect(),
+        })
     }
 }
 

--- a/src/slash_commands/mod.rs
+++ b/src/slash_commands/mod.rs
@@ -1,0 +1,107 @@
+#![cfg_attr(not(target_arch = "wasm32"), allow(dead_code))]
+
+mod typst_docs;
+mod typst_symbols;
+
+pub(crate) struct ArgumentCompletion {
+    pub label: String,
+    pub new_text: String,
+    pub run_command: bool,
+}
+
+pub(crate) struct CommandOutput {
+    pub text: String,
+    pub sections: Vec<OutputSection>,
+}
+
+pub(crate) struct OutputSection {
+    pub range: std::ops::Range<usize>,
+    pub label: String,
+}
+
+pub(crate) fn complete_typst_docs(args: &[String]) -> Vec<ArgumentCompletion> {
+    typst_docs::complete_docs(args)
+}
+
+pub(crate) fn run_typst_docs(args: &[String]) -> Result<CommandOutput, String> {
+    typst_docs::run_docs(args)
+}
+
+pub(crate) fn complete_typst_symbols(args: &[String]) -> Vec<ArgumentCompletion> {
+    typst_symbols::complete_symbols(args)
+}
+
+pub(crate) fn run_typst_symbols(args: &[String]) -> Result<CommandOutput, String> {
+    typst_symbols::run_symbols(args)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // --- complete_typst_docs ---
+
+    #[test]
+    fn complete_typst_docs_returns_all_functions_when_no_args() {
+        let completions = complete_typst_docs(&[]);
+        assert!(!completions.is_empty());
+    }
+
+    #[test]
+    fn complete_typst_docs_returns_filtered_results_when_partial_arg() {
+        let completions = complete_typst_docs(&["tex".to_string()]);
+        assert!(completions.iter().any(|c| c.label == "text"));
+    }
+
+    // --- run_typst_docs ---
+
+    #[test]
+    fn run_typst_docs_returns_output_when_valid_function() {
+        let output = run_typst_docs(&["heading".to_string()]).unwrap();
+        assert!(output.text.contains("# heading"));
+        assert!(!output.sections.is_empty());
+    }
+
+    #[test]
+    fn run_typst_docs_returns_error_when_no_args() {
+        assert!(run_typst_docs(&[]).is_err());
+    }
+
+    #[test]
+    fn run_typst_docs_returns_error_when_function_not_found() {
+        assert!(run_typst_docs(&["does_not_exist".to_string()]).is_err());
+    }
+
+    // --- complete_typst_symbols ---
+
+    #[test]
+    fn complete_typst_symbols_returns_all_categories_when_no_args() {
+        let completions = complete_typst_symbols(&[]);
+        assert!(!completions.is_empty());
+    }
+
+    #[test]
+    fn complete_typst_symbols_returns_filtered_results_when_partial_arg() {
+        let completions = complete_typst_symbols(&["log".to_string()]);
+        assert!(completions.iter().any(|c| c.new_text == "logic"));
+    }
+
+    // --- run_typst_symbols ---
+
+    #[test]
+    fn run_typst_symbols_returns_output_when_valid_category() {
+        let output = run_typst_symbols(&["arrow".to_string()]).unwrap();
+        assert!(output.text.contains("# Arrow Symbols"));
+        assert!(!output.sections.is_empty());
+    }
+
+    #[test]
+    fn run_typst_symbols_returns_error_when_no_args() {
+        assert!(run_typst_symbols(&[]).is_err());
+    }
+
+    #[test]
+    fn run_typst_symbols_returns_error_when_category_not_found() {
+        assert!(run_typst_symbols(&["xyz_invalid".to_string()]).is_err());
+    }
+}

--- a/src/slash_commands/typst_docs.rs
+++ b/src/slash_commands/typst_docs.rs
@@ -1,0 +1,765 @@
+#![cfg_attr(not(target_arch = "wasm32"), allow(dead_code))]
+
+use super::{ArgumentCompletion, CommandOutput, OutputSection};
+
+pub(crate) struct ParamDoc {
+    pub name: &'static str,
+    pub type_hint: &'static str,
+    pub description: &'static str,
+    pub default: Option<&'static str>,
+}
+
+pub(crate) struct FunctionDoc {
+    pub name: &'static str,
+    pub category: &'static str,
+    pub signature: &'static str,
+    pub description: &'static str,
+    pub parameters: &'static [ParamDoc],
+    pub example: &'static str,
+}
+
+static DOCS: &[FunctionDoc] = &[
+    // ── Text ─────────────────────────────────────────────────────────────────
+    FunctionDoc {
+        name: "text",
+        category: "text",
+        signature: "#text(font, size, weight, style, stretch, fill, tracking, spacing, baseline, overhang, ..body) -> content",
+        description: "Customizes the look and layout of text.",
+        parameters: &[
+            ParamDoc { name: "font", type_hint: "str | array", description: "A font family name or priority list.", default: Some("\"Linux Libertine\"") },
+            ParamDoc { name: "size", type_hint: "length", description: "The size of the glyphs.", default: Some("11pt") },
+            ParamDoc { name: "weight", type_hint: "int | str", description: "The font weight (e.g. \"bold\", 700).", default: Some("\"regular\"") },
+            ParamDoc { name: "fill", type_hint: "color | gradient", description: "The text color.", default: Some("black") },
+            ParamDoc { name: "body", type_hint: "content", description: "The text content.", default: None },
+        ],
+        example: "#text(font: \"New Computer Modern\", size: 12pt, fill: blue)[Hello, Typst!]",
+    },
+    FunctionDoc {
+        name: "emph",
+        category: "text",
+        signature: "#emph(body) -> content",
+        description: "Emphasizes content by italicizing it.",
+        parameters: &[
+            ParamDoc { name: "body", type_hint: "content", description: "The content to emphasize.", default: None },
+        ],
+        example: "This is _emphasized_ or #emph[emphasized].",
+    },
+    FunctionDoc {
+        name: "strong",
+        category: "text",
+        signature: "#strong(delta, body) -> content",
+        description: "Strongly emphasizes content by increasing font weight.",
+        parameters: &[
+            ParamDoc { name: "delta", type_hint: "int", description: "The delta to apply to the current font weight.", default: Some("300") },
+            ParamDoc { name: "body", type_hint: "content", description: "The content to strongly emphasize.", default: None },
+        ],
+        example: "This is *bold* or #strong[bold].",
+    },
+    FunctionDoc {
+        name: "underline",
+        category: "text",
+        signature: "#underline(stroke, offset, evade, background, body) -> content",
+        description: "Underlines text.",
+        parameters: &[
+            ParamDoc { name: "stroke", type_hint: "length | stroke", description: "How to stroke the line.", default: Some("auto") },
+            ParamDoc { name: "offset", type_hint: "length", description: "Position of the line relative to baseline.", default: Some("auto") },
+            ParamDoc { name: "body", type_hint: "content", description: "The content to underline.", default: None },
+        ],
+        example: "#underline[Underlined text]",
+    },
+    FunctionDoc {
+        name: "strike",
+        category: "text",
+        signature: "#strike(stroke, offset, extent, background, body) -> content",
+        description: "Strikes through text.",
+        parameters: &[
+            ParamDoc { name: "stroke", type_hint: "length | stroke", description: "How to stroke the line.", default: Some("auto") },
+            ParamDoc { name: "body", type_hint: "content", description: "The content to strike.", default: None },
+        ],
+        example: "#strike[Struck through]",
+    },
+    FunctionDoc {
+        name: "overline",
+        category: "text",
+        signature: "#overline(stroke, offset, evade, background, body) -> content",
+        description: "Adds a line over text.",
+        parameters: &[
+            ParamDoc { name: "stroke", type_hint: "length | stroke", description: "How to stroke the line.", default: Some("auto") },
+            ParamDoc { name: "body", type_hint: "content", description: "The content to overline.", default: None },
+        ],
+        example: "#overline[Overlined text]",
+    },
+    FunctionDoc {
+        name: "highlight",
+        category: "text",
+        signature: "#highlight(fill, top-edge, bottom-edge, extent, radius, body) -> content",
+        description: "Highlights text with a background color.",
+        parameters: &[
+            ParamDoc { name: "fill", type_hint: "color", description: "The color to highlight with.", default: Some("yellow") },
+            ParamDoc { name: "body", type_hint: "content", description: "The content to highlight.", default: None },
+        ],
+        example: "#highlight(fill: yellow)[Highlighted text]",
+    },
+    FunctionDoc {
+        name: "raw",
+        category: "text",
+        signature: "#raw(text, lang, block, tab-size, align) -> content",
+        description: "Displays text verbatim in a monospace font. Use backtick syntax for inline or fenced code blocks.",
+        parameters: &[
+            ParamDoc { name: "text", type_hint: "str", description: "The raw text to display.", default: None },
+            ParamDoc { name: "lang", type_hint: "str | none", description: "The language for syntax highlighting.", default: Some("none") },
+            ParamDoc { name: "block", type_hint: "bool", description: "Whether to display as a block.", default: Some("false") },
+            ParamDoc { name: "tab-size", type_hint: "int", description: "Spaces per tab.", default: Some("2") },
+        ],
+        example: "`inline code` or ```rust\nfn main() {}\n```",
+    },
+    FunctionDoc {
+        name: "smallcaps",
+        category: "text",
+        signature: "#smallcaps(body) -> content",
+        description: "Displays text in small capitals.",
+        parameters: &[
+            ParamDoc { name: "body", type_hint: "content", description: "The content to display in small caps.", default: None },
+        ],
+        example: "#smallcaps[Small Capitals]",
+    },
+    FunctionDoc {
+        name: "sub",
+        category: "text",
+        signature: "#sub(typographic, baseline, size, body) -> content",
+        description: "Renders text in subscript.",
+        parameters: &[
+            ParamDoc { name: "body", type_hint: "content", description: "The subscript content.", default: None },
+        ],
+        example: "H#sub[2]O",
+    },
+    FunctionDoc {
+        name: "super",
+        category: "text",
+        signature: "#super(typographic, baseline, size, body) -> content",
+        description: "Renders text in superscript.",
+        parameters: &[
+            ParamDoc { name: "body", type_hint: "content", description: "The superscript content.", default: None },
+        ],
+        example: "x#super[2] + y#super[2]",
+    },
+    // ── Layout ────────────────────────────────────────────────────────────────
+    FunctionDoc {
+        name: "page",
+        category: "layout",
+        signature: "#page(paper, width, height, flipped, margin, columns, fill, numbering, header, footer, ..body) -> content",
+        description: "Customizes the page settings. Used with #set to apply globally.",
+        parameters: &[
+            ParamDoc { name: "paper", type_hint: "str", description: "Paper format (e.g. \"a4\", \"us-letter\").", default: Some("\"a4\"") },
+            ParamDoc { name: "width", type_hint: "length", description: "Page width.", default: Some("auto") },
+            ParamDoc { name: "height", type_hint: "length | auto", description: "Page height.", default: Some("auto") },
+            ParamDoc { name: "margin", type_hint: "length | dict", description: "Page margins.", default: Some("auto") },
+            ParamDoc { name: "columns", type_hint: "int", description: "Number of columns.", default: Some("1") },
+            ParamDoc { name: "fill", type_hint: "color | none", description: "Page background fill.", default: Some("none") },
+            ParamDoc { name: "numbering", type_hint: "str | function | none", description: "Page number format.", default: Some("none") },
+        ],
+        example: "#set page(paper: \"a4\", margin: (x: 2cm, y: 3cm), numbering: \"1\")",
+    },
+    FunctionDoc {
+        name: "pagebreak",
+        category: "layout",
+        signature: "#pagebreak(weak, to) -> content",
+        description: "Forces a page break.",
+        parameters: &[
+            ParamDoc { name: "weak", type_hint: "bool", description: "If true, skipped if page is already empty.", default: Some("false") },
+            ParamDoc { name: "to", type_hint: "str | none", description: "\"odd\" or \"even\" to break to a specific page parity.", default: Some("none") },
+        ],
+        example: "#pagebreak()",
+    },
+    FunctionDoc {
+        name: "par",
+        category: "layout",
+        signature: "#par(leading, justify, linebreaks, first-line-indent, hanging-indent, body) -> content",
+        description: "Configures paragraph settings. Also sets the layout of implicit paragraphs.",
+        parameters: &[
+            ParamDoc { name: "leading", type_hint: "length", description: "Space between lines.", default: Some("0.65em") },
+            ParamDoc { name: "justify", type_hint: "bool", description: "Whether to justify text.", default: Some("false") },
+            ParamDoc { name: "first-line-indent", type_hint: "length", description: "Indent for first line.", default: Some("0pt") },
+            ParamDoc { name: "body", type_hint: "content", description: "Paragraph content.", default: None },
+        ],
+        example: "#set par(justify: true, leading: 0.8em)",
+    },
+    FunctionDoc {
+        name: "block",
+        category: "layout",
+        signature: "#block(width, height, breakable, fill, stroke, radius, inset, outset, spacing, above, below, clip, sticky, body) -> content",
+        description: "A block-level container with optional visual styling.",
+        parameters: &[
+            ParamDoc { name: "width", type_hint: "length | auto | fraction", description: "Block width.", default: Some("auto") },
+            ParamDoc { name: "height", type_hint: "length | auto | fraction", description: "Block height.", default: Some("auto") },
+            ParamDoc { name: "fill", type_hint: "color | none", description: "Background fill.", default: Some("none") },
+            ParamDoc { name: "stroke", type_hint: "stroke | none | dict", description: "Border stroke.", default: Some("none") },
+            ParamDoc { name: "radius", type_hint: "length | dict", description: "Border radius.", default: Some("0pt") },
+            ParamDoc { name: "inset", type_hint: "length | dict", description: "Inner padding.", default: Some("0pt") },
+            ParamDoc { name: "body", type_hint: "content | none", description: "Block content.", default: None },
+        ],
+        example: "#block(fill: luma(230), inset: 8pt, radius: 4pt)[Content in a box]",
+    },
+    FunctionDoc {
+        name: "box",
+        category: "layout",
+        signature: "#box(width, height, baseline, fill, stroke, radius, inset, outset, clip, body) -> content",
+        description: "An inline-level container.",
+        parameters: &[
+            ParamDoc { name: "width", type_hint: "length | auto | fraction", description: "Box width.", default: Some("auto") },
+            ParamDoc { name: "fill", type_hint: "color | none", description: "Background fill.", default: Some("none") },
+            ParamDoc { name: "inset", type_hint: "length | dict", description: "Inner padding.", default: Some("0pt") },
+            ParamDoc { name: "body", type_hint: "content | none", description: "Box content.", default: None },
+        ],
+        example: "#box(fill: aqua, inset: 2pt)[inline box]",
+    },
+    FunctionDoc {
+        name: "stack",
+        category: "layout",
+        signature: "#stack(dir, spacing, ..children) -> content",
+        description: "Arranges content and spacing along an axis.",
+        parameters: &[
+            ParamDoc { name: "dir", type_hint: "direction", description: "Stacking direction.", default: Some("ttb") },
+            ParamDoc { name: "spacing", type_hint: "length | fraction | none", description: "Default spacing between children.", default: Some("none") },
+            ParamDoc { name: "children", type_hint: "content | length | fraction", description: "Content or spacing to stack.", default: None },
+        ],
+        example: "#stack(dir: ltr, spacing: 1em)[A][B][C]",
+    },
+    FunctionDoc {
+        name: "grid",
+        category: "layout",
+        signature: "#grid(columns, rows, gutter, column-gutter, row-gutter, fill, align, stroke, inset, ..children) -> content",
+        description: "Arranges content in a grid.",
+        parameters: &[
+            ParamDoc { name: "columns", type_hint: "int | array | auto", description: "Column widths or count.", default: Some("auto") },
+            ParamDoc { name: "rows", type_hint: "int | array | auto", description: "Row heights or count.", default: Some("auto") },
+            ParamDoc { name: "gutter", type_hint: "length | array", description: "Spacing between rows and columns.", default: Some("0pt") },
+            ParamDoc { name: "fill", type_hint: "color | none | function", description: "Cell background fill.", default: Some("none") },
+            ParamDoc { name: "children", type_hint: "content", description: "Grid cells.", default: None },
+        ],
+        example: "#grid(columns: (1fr, 1fr), gutter: 1em)[Left][Right]",
+    },
+    FunctionDoc {
+        name: "columns",
+        category: "layout",
+        signature: "#columns(count, gutter, body) -> content",
+        description: "Separates a region into multiple columns.",
+        parameters: &[
+            ParamDoc { name: "count", type_hint: "int", description: "Number of columns.", default: Some("2") },
+            ParamDoc { name: "gutter", type_hint: "length", description: "Space between columns.", default: Some("4%") },
+            ParamDoc { name: "body", type_hint: "content", description: "Content to lay out in columns.", default: None },
+        ],
+        example: "#columns(2, gutter: 2em)[Column content here...]",
+    },
+    FunctionDoc {
+        name: "align",
+        category: "layout",
+        signature: "#align(alignment, body) -> content",
+        description: "Aligns content horizontally and vertically.",
+        parameters: &[
+            ParamDoc { name: "alignment", type_hint: "alignment", description: "Alignment (left, right, center, top, bottom, horizon, etc.).", default: Some("start + top") },
+            ParamDoc { name: "body", type_hint: "content", description: "Content to align.", default: None },
+        ],
+        example: "#align(center)[Centered text]\n#align(right)[Right-aligned]",
+    },
+    FunctionDoc {
+        name: "pad",
+        category: "layout",
+        signature: "#pad(x, y, top, right, bottom, left, rest, body) -> content",
+        description: "Adds padding around content.",
+        parameters: &[
+            ParamDoc { name: "x", type_hint: "length | relative | fraction", description: "Horizontal padding shorthand.", default: Some("0pt") },
+            ParamDoc { name: "y", type_hint: "length | relative | fraction", description: "Vertical padding shorthand.", default: Some("0pt") },
+            ParamDoc { name: "body", type_hint: "content", description: "The padded content.", default: None },
+        ],
+        example: "#pad(x: 2em, y: 1em)[Padded content]",
+    },
+    FunctionDoc {
+        name: "place",
+        category: "layout",
+        signature: "#place(alignment, dx, dy, float, clearance, body) -> content",
+        description: "Places content at an absolute position.",
+        parameters: &[
+            ParamDoc { name: "alignment", type_hint: "alignment | auto", description: "Where to place relative to.", default: Some("start + top") },
+            ParamDoc { name: "dx", type_hint: "length | relative", description: "Horizontal offset.", default: Some("0%") },
+            ParamDoc { name: "dy", type_hint: "length | relative", description: "Vertical offset.", default: Some("0%") },
+            ParamDoc { name: "float", type_hint: "bool", description: "Whether to float to top or bottom of page.", default: Some("false") },
+            ParamDoc { name: "body", type_hint: "content", description: "Content to place.", default: None },
+        ],
+        example: "#place(top + right, dx: -1cm)[Watermark]",
+    },
+    FunctionDoc {
+        name: "colbreak",
+        category: "layout",
+        signature: "#colbreak(weak) -> content",
+        description: "Forces a column break.",
+        parameters: &[
+            ParamDoc { name: "weak", type_hint: "bool", description: "If true, skipped when at the start of a column.", default: Some("false") },
+        ],
+        example: "#colbreak()",
+    },
+    FunctionDoc {
+        name: "v",
+        category: "layout",
+        signature: "#v(amount, weak) -> content",
+        description: "Inserts vertical spacing.",
+        parameters: &[
+            ParamDoc { name: "amount", type_hint: "length | fraction", description: "How much vertical space to add.", default: None },
+            ParamDoc { name: "weak", type_hint: "bool", description: "Whether to collapse adjacent spaces.", default: Some("false") },
+        ],
+        example: "#v(1em) // Insert 1em vertical space",
+    },
+    FunctionDoc {
+        name: "h",
+        category: "layout",
+        signature: "#h(amount, weak) -> content",
+        description: "Inserts horizontal spacing.",
+        parameters: &[
+            ParamDoc { name: "amount", type_hint: "length | fraction", description: "How much horizontal space to add.", default: None },
+            ParamDoc { name: "weak", type_hint: "bool", description: "Whether to collapse adjacent spaces.", default: Some("false") },
+        ],
+        example: "#h(1em) // Insert 1em horizontal space",
+    },
+    // ── Structure ─────────────────────────────────────────────────────────────
+    FunctionDoc {
+        name: "heading",
+        category: "structure",
+        signature: "#heading(level, depth, offset, numbering, supplement, outlined, bookmarked, hanging-indent, body) -> content",
+        description: "A section heading. Can also be written with = syntax.",
+        parameters: &[
+            ParamDoc { name: "level", type_hint: "int", description: "Heading level (1-6).", default: Some("1") },
+            ParamDoc { name: "numbering", type_hint: "str | function | none", description: "Numbering format.", default: Some("none") },
+            ParamDoc { name: "outlined", type_hint: "bool", description: "Whether to include in outline.", default: Some("true") },
+            ParamDoc { name: "body", type_hint: "content", description: "Heading text.", default: None },
+        ],
+        example: "= Top-level Heading\n== Second-level\n#heading(level: 3)[Third]",
+    },
+    FunctionDoc {
+        name: "list",
+        category: "structure",
+        signature: "#list(tight, marker, indent, body-indent, spacing, ..children) -> content",
+        description: "A bullet list. Items can also be written with - syntax.",
+        parameters: &[
+            ParamDoc { name: "tight", type_hint: "bool", description: "Reduce spacing between items.", default: Some("true") },
+            ParamDoc { name: "marker", type_hint: "content | array | function", description: "Bullet marker.", default: Some("•") },
+            ParamDoc { name: "children", type_hint: "content", description: "List items.", default: None },
+        ],
+        example: "- First item\n- Second item\n#list[Item A][Item B]",
+    },
+    FunctionDoc {
+        name: "enum",
+        category: "structure",
+        signature: "#enum(tight, numbering, start, full, indent, body-indent, spacing, ..children) -> content",
+        description: "A numbered list. Items can also be written with + syntax.",
+        parameters: &[
+            ParamDoc { name: "tight", type_hint: "bool", description: "Reduce spacing between items.", default: Some("true") },
+            ParamDoc { name: "numbering", type_hint: "str | function", description: "Number format.", default: Some("\"1.\"") },
+            ParamDoc { name: "start", type_hint: "int", description: "Starting number.", default: Some("1") },
+            ParamDoc { name: "children", type_hint: "content", description: "Numbered list items.", default: None },
+        ],
+        example: "+ First\n+ Second\n#enum(start: 3)[Third][Fourth]",
+    },
+    FunctionDoc {
+        name: "terms",
+        category: "structure",
+        signature: "#terms(tight, separator, indent, hanging-indent, spacing, ..children) -> content",
+        description: "A term list. Items can also be written with / term: description syntax.",
+        parameters: &[
+            ParamDoc { name: "tight", type_hint: "bool", description: "Reduce spacing.", default: Some("true") },
+            ParamDoc { name: "separator", type_hint: "content", description: "Separator between term and description.", default: Some("\": \"") },
+            ParamDoc { name: "children", type_hint: "content", description: "Term list items.", default: None },
+        ],
+        example: "/ Term: Description\n/ Other: Another definition",
+    },
+    FunctionDoc {
+        name: "table",
+        category: "structure",
+        signature: "#table(columns, rows, gutter, fill, align, stroke, inset, ..children) -> content",
+        description: "A table with optional borders and fills.",
+        parameters: &[
+            ParamDoc { name: "columns", type_hint: "int | array | auto", description: "Column widths or count.", default: Some("auto") },
+            ParamDoc { name: "rows", type_hint: "int | array | auto", description: "Row heights or count.", default: Some("auto") },
+            ParamDoc { name: "fill", type_hint: "color | none | function", description: "Cell background.", default: Some("none") },
+            ParamDoc { name: "stroke", type_hint: "stroke | none | dict | function", description: "Cell border.", default: Some("1pt") },
+            ParamDoc { name: "inset", type_hint: "length | dict | function", description: "Cell padding.", default: Some("0.5em") },
+            ParamDoc { name: "children", type_hint: "content | table.cell | table.header", description: "Table cells.", default: None },
+        ],
+        example: "#table(\n  columns: 2,\n  [Name], [Value],\n  [Alpha], [1],\n  [Beta], [2],\n)",
+    },
+    FunctionDoc {
+        name: "figure",
+        category: "structure",
+        signature: "#figure(caption, kind, supplement, numbering, gap, outlined, body) -> content",
+        description: "A figure with an optional caption and numbering.",
+        parameters: &[
+            ParamDoc { name: "body", type_hint: "content", description: "The figure content.", default: None },
+            ParamDoc { name: "caption", type_hint: "content | none", description: "The figure caption.", default: Some("none") },
+            ParamDoc { name: "kind", type_hint: "str | function | auto", description: "Type of figure (image, table, etc.).", default: Some("auto") },
+            ParamDoc { name: "supplement", type_hint: "content | function | auto | none", description: "Supplement like \"Figure\".", default: Some("auto") },
+            ParamDoc { name: "numbering", type_hint: "str | function | none", description: "Number format.", default: Some("\"1\"") },
+        ],
+        example: "#figure(\n  image(\"plot.png\"),\n  caption: [Result of experiment]\n)",
+    },
+    FunctionDoc {
+        name: "outline",
+        category: "structure",
+        signature: "#outline(title, target, depth, indent, fill) -> content",
+        description: "A table of contents or outline.",
+        parameters: &[
+            ParamDoc { name: "title", type_hint: "content | auto | none", description: "Outline title.", default: Some("auto") },
+            ParamDoc { name: "target", type_hint: "label | selector | location | function", description: "Elements to include.", default: Some("heading") },
+            ParamDoc { name: "depth", type_hint: "int | none", description: "Maximum heading depth.", default: Some("none") },
+            ParamDoc { name: "indent", type_hint: "bool | length | function | auto", description: "Indentation for nested entries.", default: Some("none") },
+        ],
+        example: "#outline(title: \"Contents\", depth: 3)",
+    },
+    FunctionDoc {
+        name: "footnote",
+        category: "structure",
+        signature: "#footnote(numbering, body) -> content",
+        description: "A footnote.",
+        parameters: &[
+            ParamDoc { name: "numbering", type_hint: "str | function", description: "Number format.", default: Some("\"1\"") },
+            ParamDoc { name: "body", type_hint: "content | label", description: "Footnote content or reference.", default: None },
+        ],
+        example: "Text with a footnote.#footnote[This is the footnote.]",
+    },
+    FunctionDoc {
+        name: "quote",
+        category: "structure",
+        signature: "#quote(block, quotes, attribution, body) -> content",
+        description: "Displays a quotation.",
+        parameters: &[
+            ParamDoc { name: "block", type_hint: "bool", description: "Display as block quote.", default: Some("false") },
+            ParamDoc { name: "quotes", type_hint: "bool | auto", description: "Whether to add quotation marks.", default: Some("auto") },
+            ParamDoc { name: "attribution", type_hint: "content | label | none", description: "Attribution source.", default: Some("none") },
+            ParamDoc { name: "body", type_hint: "content", description: "The quoted text.", default: None },
+        ],
+        example: "#quote(block: true, attribution: [Author])[Quoted text here.]",
+    },
+    FunctionDoc {
+        name: "bibliography",
+        category: "structure",
+        signature: "#bibliography(path, title, full, style) -> content",
+        description: "Shows a bibliography from a BibTeX or Hayagriva file.",
+        parameters: &[
+            ParamDoc { name: "path", type_hint: "str | array", description: "Path to bibliography file(s).", default: None },
+            ParamDoc { name: "title", type_hint: "content | auto | none", description: "Bibliography title.", default: Some("auto") },
+            ParamDoc { name: "full", type_hint: "bool", description: "Include all entries, even uncited.", default: Some("false") },
+            ParamDoc { name: "style", type_hint: "str", description: "Citation style (e.g. \"ieee\", \"apa\").", default: Some("\"ieee\"") },
+        ],
+        example: "#bibliography(\"refs.bib\", style: \"apa\")",
+    },
+    FunctionDoc {
+        name: "ref",
+        category: "structure",
+        signature: "#ref(target, supplement) -> content",
+        description: "References a labeled element and generates a link.",
+        parameters: &[
+            ParamDoc { name: "target", type_hint: "label", description: "The label to reference.", default: None },
+            ParamDoc { name: "supplement", type_hint: "content | function | auto | none", description: "Supplement (e.g. \"Figure\").", default: Some("auto") },
+        ],
+        example: "As shown in @fig:plot...\n#figure(...) <fig:plot>",
+    },
+    // ── Media ─────────────────────────────────────────────────────────────────
+    FunctionDoc {
+        name: "image",
+        category: "media",
+        signature: "#image(path, format, width, height, alt, fit) -> content",
+        description: "Displays an image file (PNG, JPEG, GIF, SVG, or WASM).",
+        parameters: &[
+            ParamDoc { name: "path", type_hint: "str", description: "Path to the image file.", default: None },
+            ParamDoc { name: "width", type_hint: "length | auto", description: "Display width.", default: Some("auto") },
+            ParamDoc { name: "height", type_hint: "length | auto", description: "Display height.", default: Some("auto") },
+            ParamDoc { name: "alt", type_hint: "str | none", description: "Alt text for accessibility.", default: Some("none") },
+            ParamDoc { name: "fit", type_hint: "str", description: "Fit mode: \"cover\", \"contain\", \"stretch\".", default: Some("\"cover\"") },
+        ],
+        example: "#image(\"logo.png\", width: 50%)",
+    },
+    FunctionDoc {
+        name: "line",
+        category: "media",
+        signature: "#line(start, end, length, angle, stroke) -> content",
+        description: "Draws a line.",
+        parameters: &[
+            ParamDoc { name: "start", type_hint: "array", description: "Start point (x, y).", default: Some("(0%, 0%)") },
+            ParamDoc { name: "end", type_hint: "array | none", description: "End point (x, y).", default: Some("none") },
+            ParamDoc { name: "length", type_hint: "length", description: "Line length when end is unset.", default: Some("0pt") },
+            ParamDoc { name: "angle", type_hint: "angle", description: "Line angle when end is unset.", default: Some("0deg") },
+            ParamDoc { name: "stroke", type_hint: "length | color | stroke", description: "Line style.", default: Some("1pt") },
+        ],
+        example: "#line(length: 100%, stroke: 1pt + gray)",
+    },
+    FunctionDoc {
+        name: "rect",
+        category: "media",
+        signature: "#rect(width, height, fill, stroke, radius, inset, outset, body) -> content",
+        description: "Draws a rectangle.",
+        parameters: &[
+            ParamDoc { name: "width", type_hint: "length | auto", description: "Rectangle width.", default: Some("auto") },
+            ParamDoc { name: "height", type_hint: "length | auto", description: "Rectangle height.", default: Some("auto") },
+            ParamDoc { name: "fill", type_hint: "color | none", description: "Fill color.", default: Some("none") },
+            ParamDoc { name: "stroke", type_hint: "stroke | none | dict", description: "Border stroke.", default: Some("auto") },
+            ParamDoc { name: "radius", type_hint: "length | dict", description: "Corner radius.", default: Some("0pt") },
+            ParamDoc { name: "body", type_hint: "content | none", description: "Content inside.", default: Some("none") },
+        ],
+        example: "#rect(width: 100%, fill: blue.lighten(90%), radius: 4pt)[Inside rect]",
+    },
+    FunctionDoc {
+        name: "circle",
+        category: "media",
+        signature: "#circle(radius, width, height, fill, stroke, inset, outset, body) -> content",
+        description: "Draws a circle.",
+        parameters: &[
+            ParamDoc { name: "radius", type_hint: "length", description: "Circle radius.", default: Some("auto") },
+            ParamDoc { name: "fill", type_hint: "color | none", description: "Fill color.", default: Some("none") },
+            ParamDoc { name: "stroke", type_hint: "stroke | none", description: "Border stroke.", default: Some("auto") },
+            ParamDoc { name: "body", type_hint: "content | none", description: "Content inside.", default: Some("none") },
+        ],
+        example: "#circle(radius: 1cm, fill: red)",
+    },
+    FunctionDoc {
+        name: "ellipse",
+        category: "media",
+        signature: "#ellipse(width, height, fill, stroke, inset, outset, body) -> content",
+        description: "Draws an ellipse.",
+        parameters: &[
+            ParamDoc { name: "width", type_hint: "length | auto", description: "Ellipse width.", default: Some("auto") },
+            ParamDoc { name: "height", type_hint: "length | auto", description: "Ellipse height.", default: Some("auto") },
+            ParamDoc { name: "fill", type_hint: "color | none", description: "Fill color.", default: Some("none") },
+            ParamDoc { name: "stroke", type_hint: "stroke | none", description: "Border stroke.", default: Some("auto") },
+            ParamDoc { name: "body", type_hint: "content | none", description: "Content inside.", default: Some("none") },
+        ],
+        example: "#ellipse(width: 3cm, height: 1cm, fill: green)",
+    },
+    FunctionDoc {
+        name: "polygon",
+        category: "media",
+        signature: "#polygon(fill, stroke, ..vertices) -> content",
+        description: "Draws a polygon through a list of vertices.",
+        parameters: &[
+            ParamDoc { name: "fill", type_hint: "color | none", description: "Fill color.", default: Some("none") },
+            ParamDoc { name: "stroke", type_hint: "stroke | none", description: "Border stroke.", default: Some("auto") },
+            ParamDoc { name: "vertices", type_hint: "array", description: "List of (x, y) points.", default: None },
+        ],
+        example: "#polygon(fill: blue, (0pt, 0pt), (30pt, 0pt), (15pt, 26pt))",
+    },
+    // ── Math ──────────────────────────────────────────────────────────────────
+    FunctionDoc {
+        name: "equation",
+        category: "math",
+        signature: "#equation(block, numbering, supplement, body) -> content",
+        description: "A math equation. Use $...$ for inline, $ ... $ (with spaces) for block.",
+        parameters: &[
+            ParamDoc { name: "block", type_hint: "bool", description: "Display as block (centered) equation.", default: Some("false") },
+            ParamDoc { name: "numbering", type_hint: "str | function | none", description: "Equation number format.", default: Some("none") },
+            ParamDoc { name: "body", type_hint: "content", description: "The math content.", default: None },
+        ],
+        example: "$E = m c^2$ (inline)\n$ F = m a $ (block)",
+    },
+    // ── Meta ──────────────────────────────────────────────────────────────────
+    FunctionDoc {
+        name: "link",
+        category: "meta",
+        signature: "#link(dest, body) -> content",
+        description: "Links to a URL or labeled element.",
+        parameters: &[
+            ParamDoc { name: "dest", type_hint: "str | label | location", description: "URL or target label.", default: None },
+            ParamDoc { name: "body", type_hint: "content", description: "Link text (defaults to destination).", default: None },
+        ],
+        example: "#link(\"https://typst.app\")[Typst website]",
+    },
+    FunctionDoc {
+        name: "cite",
+        category: "meta",
+        signature: "#cite(key, supplement, form, style) -> content",
+        description: "Cites a bibliography entry.",
+        parameters: &[
+            ParamDoc { name: "key", type_hint: "label", description: "Bibliography key.", default: None },
+            ParamDoc { name: "supplement", type_hint: "content | none", description: "Additional info (page, etc.).", default: Some("none") },
+            ParamDoc { name: "form", type_hint: "str | none", description: "Citation form: \"normal\", \"prose\", \"full\", \"author\", \"year\".", default: Some("\"normal\"") },
+        ],
+        example: "@knuth1984 or #cite(<knuth1984>, supplement: [p. 42])",
+    },
+];
+
+pub(crate) fn find_function(name: &str) -> Option<&'static FunctionDoc> {
+    DOCS.iter().find(|d| d.name.eq_ignore_ascii_case(name))
+}
+
+pub(crate) fn search_functions(query: &str) -> Vec<&'static FunctionDoc> {
+    let q = query.to_ascii_lowercase();
+    DOCS.iter()
+        .filter(|d| d.name.starts_with(q.as_str()) || d.name.contains(q.as_str()))
+        .collect()
+}
+
+pub(crate) fn list_functions() -> &'static [FunctionDoc] {
+    DOCS
+}
+
+pub(crate) fn complete_docs(args: &[String]) -> Vec<ArgumentCompletion> {
+    let query = args.first().map(String::as_str).unwrap_or("");
+    let funcs: Vec<&FunctionDoc> = if query.is_empty() {
+        DOCS.iter().collect()
+    } else {
+        search_functions(query)
+    };
+    funcs
+        .into_iter()
+        .map(|f| ArgumentCompletion {
+            label: f.name.to_string(),
+            new_text: f.name.to_string(),
+            run_command: true,
+        })
+        .collect()
+}
+
+pub(crate) fn run_docs(args: &[String]) -> Result<CommandOutput, String> {
+    let name = args
+        .first()
+        .map(String::as_str)
+        .filter(|s| !s.is_empty())
+        .ok_or_else(|| "Usage: /typst-docs <function-name>".to_string())?;
+    let doc = find_function(name)
+        .ok_or_else(|| format!("Function '{}' not found. Use /typst-docs with no argument to see available functions.", name))?;
+    Ok(format_function_doc(doc))
+}
+
+fn format_function_doc(doc: &FunctionDoc) -> CommandOutput {
+    let mut text = String::new();
+
+    text.push_str(&format!("# {}\n\n", doc.name));
+    text.push_str(&format!("**Category:** {}\n\n", doc.category));
+    text.push_str(&format!("## Description\n{}\n\n", doc.description));
+    text.push_str(&format!("## Signature\n```typst\n{}\n```\n\n", doc.signature));
+
+    if !doc.parameters.is_empty() {
+        text.push_str("## Parameters\n\n");
+        text.push_str("| Parameter | Type | Default | Description |\n");
+        text.push_str("|-----------|------|---------|-------------|\n");
+        for p in doc.parameters {
+            let default = p.default.unwrap_or("-");
+            text.push_str(&format!(
+                "| `{}` | `{}` | `{}` | {} |\n",
+                p.name, p.type_hint, default, p.description
+            ));
+        }
+        text.push('\n');
+    }
+
+    if !doc.example.is_empty() {
+        text.push_str(&format!("## Example\n```typst\n{}\n```\n", doc.example));
+    }
+
+    let len = text.len();
+    CommandOutput {
+        sections: vec![OutputSection {
+            range: 0..len,
+            label: format!("typst-docs: {}", doc.name),
+        }],
+        text,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // --- find_function ---
+
+    #[test]
+    fn find_function_returns_doc_when_name_matches_exactly() {
+        let doc = find_function("text").unwrap();
+        assert_eq!(doc.name, "text");
+    }
+
+    #[test]
+    fn find_function_returns_doc_when_name_differs_in_case() {
+        let doc = find_function("TEXT").unwrap();
+        assert_eq!(doc.name, "text");
+    }
+
+    #[test]
+    fn find_function_returns_none_when_name_not_found() {
+        assert!(find_function("nonexistent_xyz").is_none());
+    }
+
+    // --- search_functions ---
+
+    #[test]
+    fn search_functions_returns_matches_when_prefix_matches() {
+        let results = search_functions("he");
+        assert!(results.iter().any(|d| d.name == "heading"));
+    }
+
+    #[test]
+    fn search_functions_returns_empty_when_no_match() {
+        let results = search_functions("zzz_no_match");
+        assert!(results.is_empty());
+    }
+
+    // --- complete_docs ---
+
+    #[test]
+    fn complete_docs_returns_all_functions_when_no_args() {
+        let completions = complete_docs(&[]);
+        assert_eq!(completions.len(), list_functions().len());
+    }
+
+    #[test]
+    fn complete_docs_returns_filtered_results_when_partial_arg() {
+        let completions = complete_docs(&["im".to_string()]);
+        assert!(completions.iter().any(|c| c.label == "image"));
+    }
+
+    #[test]
+    fn complete_docs_sets_run_command_true() {
+        let completions = complete_docs(&["text".to_string()]);
+        assert!(completions.iter().all(|c| c.run_command));
+    }
+
+    // --- run_docs ---
+
+    #[test]
+    fn run_docs_returns_output_when_valid_function() {
+        let output = run_docs(&["text".to_string()]).unwrap();
+        assert!(output.text.contains("# text"));
+        assert!(output.text.contains("## Signature"));
+    }
+
+    #[test]
+    fn run_docs_returns_error_when_no_args() {
+        assert!(run_docs(&[]).is_err());
+    }
+
+    #[test]
+    fn run_docs_returns_error_when_function_not_found() {
+        assert!(run_docs(&["nonexistent".to_string()]).is_err());
+    }
+
+    // --- format_function_doc ---
+
+    #[test]
+    fn format_function_doc_section_range_spans_entire_text() {
+        let doc = find_function("image").unwrap();
+        let output = format_function_doc(doc);
+        assert_eq!(output.sections.len(), 1);
+        assert_eq!(output.sections[0].range.end, output.text.len());
+    }
+
+    #[test]
+    fn format_function_doc_includes_parameters_table_when_params_exist() {
+        let doc = find_function("table").unwrap();
+        let output = format_function_doc(doc);
+        assert!(output.text.contains("## Parameters"));
+        assert!(output.text.contains("| Parameter |"));
+    }
+
+    #[test]
+    fn format_function_doc_includes_example_when_present() {
+        let doc = find_function("image").unwrap();
+        let output = format_function_doc(doc);
+        assert!(output.text.contains("## Example"));
+    }
+}

--- a/src/slash_commands/typst_symbols.rs
+++ b/src/slash_commands/typst_symbols.rs
@@ -1,0 +1,412 @@
+#![cfg_attr(not(target_arch = "wasm32"), allow(dead_code))]
+
+use super::{ArgumentCompletion, CommandOutput, OutputSection};
+
+pub(crate) struct SymbolEntry {
+    pub name: &'static str,
+    pub codepoint: &'static str,
+    pub typst_syntax: &'static str,
+}
+
+pub(crate) struct SymbolCategory {
+    pub name: &'static str,
+    pub description: &'static str,
+    pub symbols: &'static [SymbolEntry],
+}
+
+static CATEGORIES: &[SymbolCategory] = &[
+    SymbolCategory {
+        name: "arrow",
+        description: "Arrow symbols for use in math mode.",
+        symbols: &[
+            SymbolEntry { name: "arrow.r", codepoint: "→", typst_syntax: "$arrow.r$" },
+            SymbolEntry { name: "arrow.l", codepoint: "←", typst_syntax: "$arrow.l$" },
+            SymbolEntry { name: "arrow.t", codepoint: "↑", typst_syntax: "$arrow.t$" },
+            SymbolEntry { name: "arrow.b", codepoint: "↓", typst_syntax: "$arrow.b$" },
+            SymbolEntry { name: "arrow.l.r", codepoint: "↔", typst_syntax: "$arrow.l.r$" },
+            SymbolEntry { name: "arrow.t.b", codepoint: "↕", typst_syntax: "$arrow.t.b$" },
+            SymbolEntry { name: "arrow.r.long", codepoint: "⟶", typst_syntax: "$arrow.r.long$" },
+            SymbolEntry { name: "arrow.l.long", codepoint: "⟵", typst_syntax: "$arrow.l.long$" },
+            SymbolEntry { name: "arrow.r.double", codepoint: "⇒", typst_syntax: "$arrow.r.double$" },
+            SymbolEntry { name: "arrow.l.double", codepoint: "⇐", typst_syntax: "$arrow.l.double$" },
+            SymbolEntry { name: "arrow.l.r.double", codepoint: "⇔", typst_syntax: "$arrow.l.r.double$" },
+            SymbolEntry { name: "arrow.r.long.double", codepoint: "⟹", typst_syntax: "$arrow.r.long.double$" },
+            SymbolEntry { name: "arrow.l.long.double", codepoint: "⟸", typst_syntax: "$arrow.l.long.double$" },
+            SymbolEntry { name: "arrow.r.bar", codepoint: "↦", typst_syntax: "$arrow.r.bar$" },
+            SymbolEntry { name: "arrow.r.hook", codepoint: "↪", typst_syntax: "$arrow.r.hook$" },
+            SymbolEntry { name: "arrow.l.hook", codepoint: "↩", typst_syntax: "$arrow.l.hook$" },
+            SymbolEntry { name: "arrow.r.twohead", codepoint: "↠", typst_syntax: "$arrow.r.twohead$" },
+            SymbolEntry { name: "arrow.r.dashed", codepoint: "⇢", typst_syntax: "$arrow.r.dashed$" },
+            SymbolEntry { name: "arrow.l.dashed", codepoint: "⇠", typst_syntax: "$arrow.l.dashed$" },
+            SymbolEntry { name: "arrow.curve.r", codepoint: "↷", typst_syntax: "$arrow.curve.r$" },
+            SymbolEntry { name: "arrow.curve.l", codepoint: "↶", typst_syntax: "$arrow.curve.l$" },
+        ],
+    },
+    SymbolCategory {
+        name: "greek",
+        description: "Greek letters (lowercase and uppercase) for math mode.",
+        symbols: &[
+            SymbolEntry { name: "alpha", codepoint: "α", typst_syntax: "$alpha$" },
+            SymbolEntry { name: "beta", codepoint: "β", typst_syntax: "$beta$" },
+            SymbolEntry { name: "gamma", codepoint: "γ", typst_syntax: "$gamma$" },
+            SymbolEntry { name: "delta", codepoint: "δ", typst_syntax: "$delta$" },
+            SymbolEntry { name: "epsilon", codepoint: "ε", typst_syntax: "$epsilon$" },
+            SymbolEntry { name: "zeta", codepoint: "ζ", typst_syntax: "$zeta$" },
+            SymbolEntry { name: "eta", codepoint: "η", typst_syntax: "$eta$" },
+            SymbolEntry { name: "theta", codepoint: "θ", typst_syntax: "$theta$" },
+            SymbolEntry { name: "iota", codepoint: "ι", typst_syntax: "$iota$" },
+            SymbolEntry { name: "kappa", codepoint: "κ", typst_syntax: "$kappa$" },
+            SymbolEntry { name: "lambda", codepoint: "λ", typst_syntax: "$lambda$" },
+            SymbolEntry { name: "mu", codepoint: "μ", typst_syntax: "$mu$" },
+            SymbolEntry { name: "nu", codepoint: "ν", typst_syntax: "$nu$" },
+            SymbolEntry { name: "xi", codepoint: "ξ", typst_syntax: "$xi$" },
+            SymbolEntry { name: "pi", codepoint: "π", typst_syntax: "$pi$" },
+            SymbolEntry { name: "rho", codepoint: "ρ", typst_syntax: "$rho$" },
+            SymbolEntry { name: "sigma", codepoint: "σ", typst_syntax: "$sigma$" },
+            SymbolEntry { name: "tau", codepoint: "τ", typst_syntax: "$tau$" },
+            SymbolEntry { name: "upsilon", codepoint: "υ", typst_syntax: "$upsilon$" },
+            SymbolEntry { name: "phi", codepoint: "φ", typst_syntax: "$phi$" },
+            SymbolEntry { name: "chi", codepoint: "χ", typst_syntax: "$chi$" },
+            SymbolEntry { name: "psi", codepoint: "ψ", typst_syntax: "$psi$" },
+            SymbolEntry { name: "omega", codepoint: "ω", typst_syntax: "$omega$" },
+            SymbolEntry { name: "Alpha", codepoint: "Α", typst_syntax: "$Alpha$" },
+            SymbolEntry { name: "Beta", codepoint: "Β", typst_syntax: "$Beta$" },
+            SymbolEntry { name: "Gamma", codepoint: "Γ", typst_syntax: "$Gamma$" },
+            SymbolEntry { name: "Delta", codepoint: "Δ", typst_syntax: "$Delta$" },
+            SymbolEntry { name: "Epsilon", codepoint: "Ε", typst_syntax: "$Epsilon$" },
+            SymbolEntry { name: "Zeta", codepoint: "Ζ", typst_syntax: "$Zeta$" },
+            SymbolEntry { name: "Eta", codepoint: "Η", typst_syntax: "$Eta$" },
+            SymbolEntry { name: "Theta", codepoint: "Θ", typst_syntax: "$Theta$" },
+            SymbolEntry { name: "Iota", codepoint: "Ι", typst_syntax: "$Iota$" },
+            SymbolEntry { name: "Kappa", codepoint: "Κ", typst_syntax: "$Kappa$" },
+            SymbolEntry { name: "Lambda", codepoint: "Λ", typst_syntax: "$Lambda$" },
+            SymbolEntry { name: "Mu", codepoint: "Μ", typst_syntax: "$Mu$" },
+            SymbolEntry { name: "Nu", codepoint: "Ν", typst_syntax: "$Nu$" },
+            SymbolEntry { name: "Xi", codepoint: "Ξ", typst_syntax: "$Xi$" },
+            SymbolEntry { name: "Pi", codepoint: "Π", typst_syntax: "$Pi$" },
+            SymbolEntry { name: "Rho", codepoint: "Ρ", typst_syntax: "$Rho$" },
+            SymbolEntry { name: "Sigma", codepoint: "Σ", typst_syntax: "$Sigma$" },
+            SymbolEntry { name: "Tau", codepoint: "Τ", typst_syntax: "$Tau$" },
+            SymbolEntry { name: "Upsilon", codepoint: "Υ", typst_syntax: "$Upsilon$" },
+            SymbolEntry { name: "Phi", codepoint: "Φ", typst_syntax: "$Phi$" },
+            SymbolEntry { name: "Chi", codepoint: "Χ", typst_syntax: "$Chi$" },
+            SymbolEntry { name: "Psi", codepoint: "Ψ", typst_syntax: "$Psi$" },
+            SymbolEntry { name: "Omega", codepoint: "Ω", typst_syntax: "$Omega$" },
+        ],
+    },
+    SymbolCategory {
+        name: "operator",
+        description: "Mathematical operators.",
+        symbols: &[
+            SymbolEntry { name: "plus", codepoint: "+", typst_syntax: "$+$" },
+            SymbolEntry { name: "minus", codepoint: "−", typst_syntax: "$-$" },
+            SymbolEntry { name: "times", codepoint: "×", typst_syntax: "$times$" },
+            SymbolEntry { name: "div", codepoint: "÷", typst_syntax: "$div$" },
+            SymbolEntry { name: "plus.minus", codepoint: "±", typst_syntax: "$plus.minus$" },
+            SymbolEntry { name: "minus.plus", codepoint: "∓", typst_syntax: "$minus.plus$" },
+            SymbolEntry { name: "dot.op", codepoint: "⋅", typst_syntax: "$dot.op$" },
+            SymbolEntry { name: "star.op", codepoint: "⋆", typst_syntax: "$star.op$" },
+            SymbolEntry { name: "circle.times", codepoint: "⊗", typst_syntax: "$circle.times$" },
+            SymbolEntry { name: "circle.plus", codepoint: "⊕", typst_syntax: "$circle.plus$" },
+            SymbolEntry { name: "circle.dot", codepoint: "⊙", typst_syntax: "$circle.dot$" },
+            SymbolEntry { name: "circle.minus", codepoint: "⊖", typst_syntax: "$circle.minus$" },
+            SymbolEntry { name: "slash", codepoint: "∕", typst_syntax: "$slash$" },
+            SymbolEntry { name: "backslash", codepoint: "∖", typst_syntax: "$backslash$" },
+            SymbolEntry { name: "sqrt", codepoint: "√", typst_syntax: "$sqrt(x)$" },
+            SymbolEntry { name: "integral", codepoint: "∫", typst_syntax: "$integral$" },
+            SymbolEntry { name: "integral.double", codepoint: "∬", typst_syntax: "$integral.double$" },
+            SymbolEntry { name: "integral.triple", codepoint: "∭", typst_syntax: "$integral.triple$" },
+            SymbolEntry { name: "integral.cont", codepoint: "∮", typst_syntax: "$integral.cont$" },
+            SymbolEntry { name: "sum", codepoint: "∑", typst_syntax: "$sum$" },
+            SymbolEntry { name: "product", codepoint: "∏", typst_syntax: "$product$" },
+            SymbolEntry { name: "product.co", codepoint: "∐", typst_syntax: "$product.co$" },
+            SymbolEntry { name: "nabla", codepoint: "∇", typst_syntax: "$nabla$" },
+            SymbolEntry { name: "partial", codepoint: "∂", typst_syntax: "$partial$" },
+        ],
+    },
+    SymbolCategory {
+        name: "relation",
+        description: "Comparison and relation symbols.",
+        symbols: &[
+            SymbolEntry { name: "eq", codepoint: "=", typst_syntax: "$=$" },
+            SymbolEntry { name: "eq.not", codepoint: "≠", typst_syntax: "$eq.not$" },
+            SymbolEntry { name: "eq.triple", codepoint: "≡", typst_syntax: "$eq.triple$" },
+            SymbolEntry { name: "lt", codepoint: "<", typst_syntax: "$<$" },
+            SymbolEntry { name: "gt", codepoint: ">", typst_syntax: "$>$" },
+            SymbolEntry { name: "lt.eq", codepoint: "≤", typst_syntax: "$lt.eq$" },
+            SymbolEntry { name: "gt.eq", codepoint: "≥", typst_syntax: "$gt.eq$" },
+            SymbolEntry { name: "lt.eq.slant", codepoint: "⩽", typst_syntax: "$lt.eq.slant$" },
+            SymbolEntry { name: "gt.eq.slant", codepoint: "⩾", typst_syntax: "$gt.eq.slant$" },
+            SymbolEntry { name: "approx", codepoint: "≈", typst_syntax: "$approx$" },
+            SymbolEntry { name: "approx.not", codepoint: "≉", typst_syntax: "$approx.not$" },
+            SymbolEntry { name: "tilde.eq", codepoint: "≅", typst_syntax: "$tilde.eq$" },
+            SymbolEntry { name: "tilde.op", codepoint: "∼", typst_syntax: "$tilde.op$" },
+            SymbolEntry { name: "prec", codepoint: "≺", typst_syntax: "$prec$" },
+            SymbolEntry { name: "succ", codepoint: "≻", typst_syntax: "$succ$" },
+            SymbolEntry { name: "prec.eq", codepoint: "≼", typst_syntax: "$prec.eq$" },
+            SymbolEntry { name: "succ.eq", codepoint: "≽", typst_syntax: "$succ.eq$" },
+            SymbolEntry { name: "ll", codepoint: "≪", typst_syntax: "$ll$" },
+            SymbolEntry { name: "gg", codepoint: "≫", typst_syntax: "$gg$" },
+            SymbolEntry { name: "prop", codepoint: "∝", typst_syntax: "$prop$" },
+            SymbolEntry { name: "perp", codepoint: "⊥", typst_syntax: "$perp$" },
+            SymbolEntry { name: "parallel", codepoint: "∥", typst_syntax: "$parallel$" },
+        ],
+    },
+    SymbolCategory {
+        name: "set",
+        description: "Set theory symbols.",
+        symbols: &[
+            SymbolEntry { name: "union", codepoint: "∪", typst_syntax: "$union$" },
+            SymbolEntry { name: "sect", codepoint: "∩", typst_syntax: "$sect$" },
+            SymbolEntry { name: "in", codepoint: "∈", typst_syntax: "$in$" },
+            SymbolEntry { name: "in.not", codepoint: "∉", typst_syntax: "$in.not$" },
+            SymbolEntry { name: "in.rev", codepoint: "∋", typst_syntax: "$in.rev$" },
+            SymbolEntry { name: "subset", codepoint: "⊂", typst_syntax: "$subset$" },
+            SymbolEntry { name: "supset", codepoint: "⊃", typst_syntax: "$supset$" },
+            SymbolEntry { name: "subset.eq", codepoint: "⊆", typst_syntax: "$subset.eq$" },
+            SymbolEntry { name: "supset.eq", codepoint: "⊇", typst_syntax: "$supset.eq$" },
+            SymbolEntry { name: "subset.not", codepoint: "⊄", typst_syntax: "$subset.not$" },
+            SymbolEntry { name: "supset.not", codepoint: "⊅", typst_syntax: "$supset.not$" },
+            SymbolEntry { name: "subset.eq.not", codepoint: "⊈", typst_syntax: "$subset.eq.not$" },
+            SymbolEntry { name: "union.sq", codepoint: "⊔", typst_syntax: "$union.sq$" },
+            SymbolEntry { name: "sect.sq", codepoint: "⊓", typst_syntax: "$sect.sq$" },
+            SymbolEntry { name: "nothing", codepoint: "∅", typst_syntax: "$nothing$" },
+            SymbolEntry { name: "complement", codepoint: "∁", typst_syntax: "$complement$" },
+        ],
+    },
+    SymbolCategory {
+        name: "logic",
+        description: "Logical symbols.",
+        symbols: &[
+            SymbolEntry { name: "and", codepoint: "∧", typst_syntax: "$and$" },
+            SymbolEntry { name: "or", codepoint: "∨", typst_syntax: "$or$" },
+            SymbolEntry { name: "not", codepoint: "¬", typst_syntax: "$not$" },
+            SymbolEntry { name: "xor", codepoint: "⊕", typst_syntax: "$xor$" },
+            SymbolEntry { name: "forall", codepoint: "∀", typst_syntax: "$forall$" },
+            SymbolEntry { name: "exists", codepoint: "∃", typst_syntax: "$exists$" },
+            SymbolEntry { name: "exists.not", codepoint: "∄", typst_syntax: "$exists.not$" },
+            SymbolEntry { name: "tack.r", codepoint: "⊢", typst_syntax: "$tack.r$" },
+            SymbolEntry { name: "tack.l", codepoint: "⊣", typst_syntax: "$tack.l$" },
+            SymbolEntry { name: "tack.r.double", codepoint: "⊨", typst_syntax: "$tack.r.double$" },
+            SymbolEntry { name: "top", codepoint: "⊤", typst_syntax: "$top$" },
+            SymbolEntry { name: "bot", codepoint: "⊥", typst_syntax: "$bot$" },
+        ],
+    },
+    SymbolCategory {
+        name: "accent",
+        description: "Accent marks for math mode. Apply with: #math.accent(x, mark).",
+        symbols: &[
+            SymbolEntry { name: "hat", codepoint: "̂", typst_syntax: "$hat(x)$" },
+            SymbolEntry { name: "tilde", codepoint: "̃", typst_syntax: "$tilde(x)$" },
+            SymbolEntry { name: "macron", codepoint: "̄", typst_syntax: "$macron(x)$" },
+            SymbolEntry { name: "breve", codepoint: "̆", typst_syntax: "$breve(x)$" },
+            SymbolEntry { name: "dot", codepoint: "̇", typst_syntax: "$dot(x)$" },
+            SymbolEntry { name: "dot.double", codepoint: "̈", typst_syntax: "$dot.double(x)$" },
+            SymbolEntry { name: "acute", codepoint: "́", typst_syntax: "$acute(x)$" },
+            SymbolEntry { name: "grave", codepoint: "̀", typst_syntax: "$grave(x)$" },
+            SymbolEntry { name: "arrow", codepoint: "⃗", typst_syntax: "$arrow(x)$" },
+        ],
+    },
+    SymbolCategory {
+        name: "misc",
+        description: "Miscellaneous mathematical symbols.",
+        symbols: &[
+            SymbolEntry { name: "infinity", codepoint: "∞", typst_syntax: "$infinity$" },
+            SymbolEntry { name: "dots.h", codepoint: "…", typst_syntax: "$dots.h$" },
+            SymbolEntry { name: "dots.v", codepoint: "⋮", typst_syntax: "$dots.v$" },
+            SymbolEntry { name: "dots.c", codepoint: "⋯", typst_syntax: "$dots.c$" },
+            SymbolEntry { name: "dots.down", codepoint: "⋱", typst_syntax: "$dots.down$" },
+            SymbolEntry { name: "star", codepoint: "★", typst_syntax: "$star$" },
+            SymbolEntry { name: "dagger", codepoint: "†", typst_syntax: "$dagger$" },
+            SymbolEntry { name: "dagger.double", codepoint: "‡", typst_syntax: "$dagger.double$" },
+            SymbolEntry { name: "degree", codepoint: "°", typst_syntax: "$degree$" },
+            SymbolEntry { name: "prime", codepoint: "′", typst_syntax: "$prime$" },
+            SymbolEntry { name: "prime.double", codepoint: "″", typst_syntax: "$prime.double$" },
+            SymbolEntry { name: "hash", codepoint: "#", typst_syntax: "$hash$" },
+            SymbolEntry { name: "percent", codepoint: "%", typst_syntax: "$percent$" },
+            SymbolEntry { name: "angle", codepoint: "∠", typst_syntax: "$angle$" },
+            SymbolEntry { name: "angle.right", codepoint: "∟", typst_syntax: "$angle.right$" },
+            SymbolEntry { name: "diameter", codepoint: "⌀", typst_syntax: "$diameter$" },
+            SymbolEntry { name: "bullet", codepoint: "•", typst_syntax: "$bullet$" },
+            SymbolEntry { name: "compose", codepoint: "∘", typst_syntax: "$compose$" },
+        ],
+    },
+];
+
+pub(crate) fn find_category(name: &str) -> Option<&'static SymbolCategory> {
+    CATEGORIES
+        .iter()
+        .find(|c| c.name.eq_ignore_ascii_case(name))
+}
+
+pub(crate) fn search_categories(query: &str) -> Vec<&'static SymbolCategory> {
+    let q = query.to_ascii_lowercase();
+    CATEGORIES
+        .iter()
+        .filter(|c| c.name.starts_with(q.as_str()))
+        .collect()
+}
+
+pub(crate) fn list_categories() -> &'static [SymbolCategory] {
+    CATEGORIES
+}
+
+pub(crate) fn complete_symbols(args: &[String]) -> Vec<ArgumentCompletion> {
+    let query = args.first().map(String::as_str).unwrap_or("");
+    let cats: Vec<&SymbolCategory> = if query.is_empty() {
+        CATEGORIES.iter().collect()
+    } else {
+        search_categories(query)
+    };
+    cats.into_iter()
+        .map(|c| ArgumentCompletion {
+            label: format!("{} — {}", c.name, c.description),
+            new_text: c.name.to_string(),
+            run_command: true,
+        })
+        .collect()
+}
+
+pub(crate) fn run_symbols(args: &[String]) -> Result<CommandOutput, String> {
+    let name = args
+        .first()
+        .map(String::as_str)
+        .filter(|s| !s.is_empty())
+        .ok_or_else(|| {
+            format!(
+                "Usage: /typst-symbols <category>\nAvailable categories: {}",
+                CATEGORIES
+                    .iter()
+                    .map(|c| c.name)
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            )
+        })?;
+    let cat = find_category(name)
+        .ok_or_else(|| format!("Category '{}' not found. Available: {}", name,
+            CATEGORIES.iter().map(|c| c.name).collect::<Vec<_>>().join(", ")))?;
+    Ok(format_symbol_category(cat))
+}
+
+fn format_symbol_category(cat: &SymbolCategory) -> CommandOutput {
+    let mut text = String::new();
+
+    text.push_str(&format!("# {} Symbols\n\n", capitalize(cat.name)));
+    text.push_str(&format!("{}\n\n", cat.description));
+    text.push_str("| Name | Symbol | Typst Syntax |\n");
+    text.push_str("|------|--------|--------------|\n");
+    for s in cat.symbols {
+        text.push_str(&format!("| `{}` | {} | `{}` |\n", s.name, s.codepoint, s.typst_syntax));
+    }
+
+    let len = text.len();
+    CommandOutput {
+        sections: vec![OutputSection {
+            range: 0..len,
+            label: format!("typst-symbols: {}", cat.name),
+        }],
+        text,
+    }
+}
+
+fn capitalize(s: &str) -> String {
+    let mut c = s.chars();
+    match c.next() {
+        None => String::new(),
+        Some(f) => f.to_uppercase().to_string() + c.as_str(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // --- find_category ---
+
+    #[test]
+    fn find_category_returns_category_when_name_matches() {
+        let cat = find_category("greek").unwrap();
+        assert_eq!(cat.name, "greek");
+    }
+
+    #[test]
+    fn find_category_returns_category_when_name_differs_in_case() {
+        let cat = find_category("GREEK").unwrap();
+        assert_eq!(cat.name, "greek");
+    }
+
+    #[test]
+    fn find_category_returns_none_when_name_not_found() {
+        assert!(find_category("nonexistent_category").is_none());
+    }
+
+    // --- search_categories ---
+
+    #[test]
+    fn search_categories_returns_matches_when_prefix_matches() {
+        let results = search_categories("ar");
+        assert!(results.iter().any(|c| c.name == "arrow"));
+    }
+
+    #[test]
+    fn search_categories_returns_empty_when_no_match() {
+        let results = search_categories("zzz");
+        assert!(results.is_empty());
+    }
+
+    // --- complete_symbols ---
+
+    #[test]
+    fn complete_symbols_returns_all_categories_when_no_args() {
+        let completions = complete_symbols(&[]);
+        assert_eq!(completions.len(), list_categories().len());
+    }
+
+    #[test]
+    fn complete_symbols_returns_filtered_results_when_partial_arg() {
+        let completions = complete_symbols(&["gr".to_string()]);
+        assert!(completions.iter().any(|c| c.new_text == "greek"));
+    }
+
+    #[test]
+    fn complete_symbols_sets_run_command_true() {
+        let completions = complete_symbols(&[]);
+        assert!(completions.iter().all(|c| c.run_command));
+    }
+
+    // --- run_symbols ---
+
+    #[test]
+    fn run_symbols_returns_output_when_valid_category() {
+        let output = run_symbols(&["greek".to_string()]).unwrap();
+        assert!(output.text.contains("# Greek Symbols"));
+        assert!(output.text.contains("| Name |"));
+    }
+
+    #[test]
+    fn run_symbols_returns_error_when_no_args() {
+        assert!(run_symbols(&[]).is_err());
+    }
+
+    #[test]
+    fn run_symbols_returns_error_when_category_not_found() {
+        assert!(run_symbols(&["nonexistent".to_string()]).is_err());
+    }
+
+    // --- format_symbol_category ---
+
+    #[test]
+    fn format_symbol_category_includes_table_header_when_category_found() {
+        let cat = find_category("arrow").unwrap();
+        let output = format_symbol_category(cat);
+        assert!(output.text.contains("| Name | Symbol | Typst Syntax |"));
+    }
+
+    #[test]
+    fn format_symbol_category_section_range_spans_entire_text() {
+        let cat = find_category("misc").unwrap();
+        let output = format_symbol_category(cat);
+        assert_eq!(output.sections.len(), 1);
+        assert_eq!(output.sections[0].range.end, output.text.len());
+    }
+}


### PR DESCRIPTION
## Summary

Closes #17.

Adds two slash commands for the Zed AI assistant panel that let users insert Typst documentation as context before asking AI questions.

### Commands

- **`/typst-docs [function]`** — Inserts function documentation (signature, parameters table, example) for ~35 Typst standard library functions across text, layout, structure, media, math, and meta categories
- **`/typst-symbols [category]`** — Inserts a Markdown symbol table for 8 math symbol categories: `arrow`, `greek`, `operator`, `relation`, `set`, `logic`, `accent`, `misc`

Both commands support argument tab-completion that automatically runs on selection.

### Architecture

Follows the existing `code_label.rs` pattern:
- Pure logic in `src/slash_commands/{mod,typst_docs,typst_symbols}.rs` (native-testable)
- Thin WASM adapter in `src/lib.rs` (type conversion only)
- All documentation data embedded as `&'static str` constants (no HTTP calls, consistent with WASM constraints)

## Test plan

- [x] `cargo test` — 108 tests pass (37 new tests added)
- [ ] Reload extension in Zed and type `/typst-docs text` in AI assistant panel
- [ ] Verify tab-completion shows function names
- [ ] Verify `/typst-symbols greek` shows Greek letter table

🤖 Generated with [Claude Code](https://claude.com/claude-code)